### PR TITLE
Add CI from scaffolding

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,64 @@
+name: Tests
+on:
+  pull_request:
+    branches: ['main']
+  push:
+    branches: ['main']
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v3 # v3.5.3
+      - uses: actions/setup-go@v4 # v4.0.1
+        with:
+          go-version-file: 'go.mod'
+          cache: true
+      - run: go mod download
+      - run: go build -v .
+      - name: Run linters
+        uses: golangci/golangci-lint-action@v3 # v3.6.0
+        with:
+          version: latest
+
+  generate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v4
+        with:
+          go-version: '1.20'
+      - run: go generate ./...
+      - name: git diff
+        run: |
+          git diff --compact-summary --exit-code || \
+            (echo; echo "Unexpected difference in directories after code generation. Run 'go generate ./...' command and commit."; exit 1)
+
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        terraform:
+          - '1.3.*'
+          - '1.2.*'
+          - '1.1.*'
+          - '1.0.*'
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v4
+        with:
+          go-version: '1.20'
+
+      - uses: hashicorp/setup-terraform@v2
+        with:
+          terraform_version: ${{ matrix.terraform }}
+          terraform_wrapper: false
+
+      - run: go mod download
+
+        # TODO(colin): set up env vars for acc tests
+      - run: go test -v -cover ./internal/

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,27 @@
+# Visit https://golangci-lint.run/ for usage documentation
+# and information on other useful linters
+issues:
+  max-per-linter: 0
+  max-same-issues: 0
+
+linters:
+  disable-all: true
+  enable:
+    - durationcheck
+    - errcheck
+    - exportloopref
+    - forcetypeassert
+    - godot
+    - gofmt
+    - gosimple
+    - ineffassign
+    - makezero
+    - misspell
+    - nilerr
+    - predeclared
+    - staticcheck
+    - tenv
+    - unconvert
+    - unparam
+    - unused
+    - vet

--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 The Chainguard Terraform provider manages Chainguard resources (IAM groups,
 clusters, policy etc) using Terraform.
 
+The provider is written to be compatible with the [Terraform Plugin Framework](https://developer.hashicorp.com/terraform/tutorials/providers-plugin-framework/providers-plugin-framework-provider)
+
 ## Requirements
 
 -	[Terraform](https://www.terraform.io/downloads.html) >= 0.13.x
@@ -49,13 +51,13 @@ provider_installation {
     # url = "https://storage.googleapis.com/us.artifacts.staging-enforce-cd1e.appspot.com/terraform-provider/"
 
     include = [
-      "registry.terraform.io/chainguard/chainguard",
+      "registry.terraform.io/chainguard-dev/chainguard",
     ]
   }
 
   direct {
     exclude = [
-      "registry.terraform.io/chainguard/chainguard",
+      "registry.terraform.io/chainguard-dev/chainguard",
     ]
   }
 }
@@ -69,7 +71,7 @@ environment of choice by setting the `console_api` parameter (defaults to
 terraform {
   required_providers {
     chainguard = {
-      source = "chainguard/chainguard"
+      source = "chainguard-dev/chainguard"
     }
   }
 }
@@ -94,7 +96,7 @@ be published), you can configure your Terraform CLI to do so.
 cat <<EOF > dev.tfrc
 provider_installation {
   dev_overrides {
-    "chainguard/chainguard" = "/path/to/terraform-provider-chainguard"
+    "chainguard-dev/chainguard" = "/path/to/terraform-provider-chainguard"
   }
 }
 EOF
@@ -131,41 +133,3 @@ TF_ACC=1 go test ./... -v
 ```
 
 *Note:* Acceptance tests create real resources, and often cost money to run.
-
-## Creating a release
-
-We currently release the terraform provider to our public GCS artifacts bucket along side `chainctl` binaries. The `cmd/promoter` tool automates this process. To use it build and then select a bucket and prefix for your release:
-
-```shell
-# Build the promoter
-go build -o promoter cmd/promoter/*.go
-
-# Login for some GCP application creds
-gcloud auth default-application login
-
-# NB: must run from the root of the repository
-./promoter --bucket example-bucket --prefix foo/bar
-```
-
-The promoter requires `git`, `go`, and `goreleaser` and must be run from the
-root of the repository (i.e this directory). The promoter requires write access
-to the bucket used.
-
-After you've created your release you can use it by setting your terraformrc file:
-
-```hcl
-provider_installation {
-  network_mirror {
-    url = "https://storage.googleapis.com/example-bucket/foo/bar/"
-    include = [
-      "registry.terraform.io/chainguard/chainguard",
-    ]
-  }
-
-  direct {
-    exclude = [
-      "registry.terraform.io/chainguard/chainguard",
-    ]
-  }
-}
-```

--- a/terraform-registry-manifest.json
+++ b/terraform-registry-manifest.json
@@ -1,0 +1,6 @@
+{
+  "version": 1,
+  "metadata": {
+    "protocol_versions": ["6.0"]
+  }
+}


### PR DESCRIPTION
- Add (some of) CI and supplemental files from https://github.com/hashicorp/terraform-provider-scaffolding-framework and https://github.com/chainguard-dev/terraform-provider-apko
- Update README to remove references to `cmd/promoter` and update the namespace referenced to `chainguad-dev`