### PR TITLE
add `resource_image_repo`

### DIFF
--- a/internal/provider/data_source_cluster_cidr.go
+++ b/internal/provider/data_source_cluster_cidr.go
@@ -91,8 +91,7 @@ func (d *clusterCIDRDataSource) Read(ctx context.Context, req datasource.ReadReq
 
 	// Set the ID on clusterCIDRDataSourceModel for acceptance tests.
 	// https://developer.hashicorp.com/terraform/tutorials/providers-plugin-framework/providers-plugin-framework-acceptance-testing#implement-data-source-id-attribute
-	// TODO(colin): replace this?
-	if d.prov.version == "acctest" {
+	if d.prov.testing {
 		data.ID = types.StringValue("placeholder")
 	}
 	data.CIDRBlocks = blocks

--- a/internal/provider/data_source_role.go
+++ b/internal/provider/data_source_role.go
@@ -154,10 +154,9 @@ func (d *roleDataSource) Read(ctx context.Context, req datasource.ReadRequest, r
 	if len(all.GetItems()) == 0 {
 		resp.Diagnostics.Append(dataNotFound("role", "" /* extra */, data))
 		return
-	} else if d.prov.version == "acctest" {
+	} else if d.prov.testing {
 		// Set the ID on roleDataSourceModel for acceptance tests.
 		// https://developer.hashicorp.com/terraform/tutorials/providers-plugin-framework/providers-plugin-framework-acceptance-testing#implement-data-source-id-attribute
-		// TODO(colin): replace this?
 		data.ID = types.StringValue("placeholder")
 	}
 

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -100,6 +100,7 @@ func (p *Provider) Resources(_ context.Context) []func() resource.Resource {
 		NewGroupInviteResource,
 		NewIdentityResource,
 		NewIdentityProviderResource,
+		NewImageRepoResource,
 		NewPolicyResource,
 		NewRoleResource,
 		NewRolebindingResource,
@@ -123,7 +124,7 @@ func (p *Provider) Schema(_ context.Context, _ provider.SchemaRequest, resp *pro
 
 type providerData struct {
 	client  platform.Clients
-	version string
+	testing bool
 }
 
 // Configure prepares a Chainguard API client for data sources and resources.
@@ -185,7 +186,7 @@ func (p *Provider) Configure(ctx context.Context, req provider.ConfigureRequest,
 
 	d := &providerData{
 		client:  clients,
-		version: p.version,
+		testing: p.version == "acctest",
 	}
 
 	resp.DataSourceData = d

--- a/internal/provider/resource_account_associations.go
+++ b/internal/provider/resource_account_associations.go
@@ -21,8 +21,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
-	"chainguard.dev/api/pkg/validation"
-	iam "chainguard.dev/api/proto/platform/iam/v1"
+	"chainguard.dev/sdk/pkg/validation"
+	iam "chainguard.dev/sdk/proto/platform/iam/v1"
 	"github.com/chainguard-dev/terraform-provider-chainguard/internal/validators"
 	"github.com/hashicorp/terraform-plugin-framework-validators/objectvalidator"
 )
@@ -123,7 +123,7 @@ func (r *accountAssociationsResource) Schema(_ context.Context, _ resource.Schem
 						Description: "AWS account ID",
 						Optional:    true, // This attribute is required, but only if the block is defined. See Validators.
 						Validators: []validator.String{
-							validators.RunFuncs(validation.ValidateAWSAccount),
+							validators.ValidateStringFuncs(validation.ValidateAWSAccount),
 						},
 					},
 				},

--- a/internal/provider/resource_account_associations_test.go
+++ b/internal/provider/resource_account_associations_test.go
@@ -10,7 +10,7 @@ import (
 	"os"
 	"testing"
 
-	"chainguard.dev/api/pkg/uidp"
+	"chainguard.dev/sdk/pkg/uidp"
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )

--- a/internal/provider/resource_group_invite.go
+++ b/internal/provider/resource_group_invite.go
@@ -80,7 +80,7 @@ func (r *groupInviteResource) Schema(_ context.Context, _ resource.SchemaRequest
 				Required:      true,
 				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
 				Validators: []validator.String{
-					validators.RunFuncs(checkRFC3339),
+					validators.ValidateStringFuncs(checkRFC3339),
 				},
 			},
 			"role": schema.StringAttribute{

--- a/internal/provider/resource_identity.go
+++ b/internal/provider/resource_identity.go
@@ -157,7 +157,7 @@ func (r *identityResource) Schema(_ context.Context, _ resource.SchemaRequest, r
 						Description: "AWS Account ID of AWS user",
 						Optional:    true, // This attribute is required, but only if the block is defined. See Validators.
 						Validators: []validator.String{
-							validators.RunFuncs(validation.ValidateAWSAccount),
+							validators.ValidateStringFuncs(validation.ValidateAWSAccount),
 						},
 					},
 					"aws_user_id": schema.StringAttribute{
@@ -306,7 +306,7 @@ func (r *identityResource) Schema(_ context.Context, _ resource.SchemaRequest, r
 						Description: "The RFC3339 encoded date and time at which this identity will no longer be valid.",
 						Optional:    true, // This attribute is required, but only if the block is defined. See Validators.
 						Validators: []validator.String{
-							validators.RunFuncs(checkRFC3339),
+							validators.ValidateStringFuncs(checkRFC3339),
 						},
 					},
 				},

--- a/internal/provider/resource_image_repo.go
+++ b/internal/provider/resource_image_repo.go
@@ -1,0 +1,252 @@
+/*
+Copyright 2023 Chainguard, Inc.
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package provider
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+
+	"chainguard.dev/sdk/pkg/uidp"
+	"chainguard.dev/sdk/pkg/validation"
+	registry "chainguard.dev/sdk/proto/platform/registry/v1"
+	"github.com/chainguard-dev/terraform-provider-chainguard/internal/validators"
+)
+
+// Ensure the implementation satisfies the expected interfaces.
+var (
+	_ resource.Resource                = &imageRepoResource{}
+	_ resource.ResourceWithConfigure   = &imageRepoResource{}
+	_ resource.ResourceWithImportState = &imageRepoResource{}
+)
+
+// NewImageRepoResource is a helper function to simplify the provider implementation.
+func NewImageRepoResource() resource.Resource {
+	return &imageRepoResource{}
+}
+
+// imageRepoResource is the resource implementation.
+type imageRepoResource struct {
+	managedResource
+}
+
+type imageRepoResourceModel struct {
+	ID       types.String `tfsdk:"id"`
+	Name     types.String `tfsdk:"name"`
+	ParentID types.String `tfsdk:"parent_id"`
+	Bundles  types.List   `tfsdk:"bundles"`
+}
+
+func (r *imageRepoResource) Configure(ctx context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	r.configure(ctx, req, resp)
+}
+
+// Metadata returns the resource type name.
+func (r *imageRepoResource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_image_repo"
+}
+
+// Schema defines the schema for the resource.
+func (r *imageRepoResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Description: "Image repo (note: delete is purposefully a no-op).",
+		Attributes: map[string]schema.Attribute{
+			"id": schema.StringAttribute{
+				Description:   "The UIDP of this repo.",
+				Computed:      true,
+				PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
+			},
+			"name": schema.StringAttribute{
+				Description: "The name of this repo.",
+				Required:    true,
+			},
+			"parent_id": schema.StringAttribute{
+				Description:   "The group that owns the repo.",
+				Required:      true,
+				PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
+				Validators: []validator.String{
+					validators.UIDP(false /* allowRootSentinel */),
+				},
+			},
+			"bundles": schema.ListAttribute{
+				Description: "List of bundles associated with this repo (a-z freeform keywords for sales purposes).",
+				Optional:    true,
+				ElementType: types.StringType,
+				Validators: []validator.List{
+					listvalidator.ValueStringsAre(validators.ValidateStringFuncs(validBundlesValue)),
+				},
+			},
+		},
+	}
+}
+
+// validBundlesValue implements validators.ValidateStringFunc
+func validBundlesValue(s string) error {
+	if err := validation.ValidateBundles([]string{s}); err != nil {
+		return fmt.Errorf("bundle item %q is invalid: %w", s, err)
+	}
+	return nil
+}
+
+// ImportState imports resources by ID into the current Terraform state.
+func (r *imageRepoResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
+}
+
+// Create creates the resource and sets the initial Terraform state.
+func (r *imageRepoResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	// Read the plan data into the resource model.
+	var plan imageRepoResourceModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	tflog.Info(ctx, fmt.Sprintf("create image repo request: name=%s, parent_id=%s", plan.Name, plan.ParentID))
+
+	bundles := make([]string, 0, len(plan.Bundles.Elements()))
+	resp.Diagnostics.Append(plan.Bundles.ElementsAs(ctx, &bundles, false /* allowUnhandled */)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	repo, err := r.prov.client.Registry().Registry().CreateRepo(ctx, &registry.CreateRepoRequest{
+		ParentId: plan.ParentID.ValueString(),
+		Repo: &registry.Repo{
+			Name:    plan.Name.ValueString(),
+			Bundles: bundles,
+		},
+	})
+	if err != nil {
+		resp.Diagnostics.Append(errorToDiagnostic(err, "failed to create image repo"))
+		return
+	}
+
+	// Save repo details in the state.
+	plan.ID = types.StringValue(repo.Id)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
+}
+
+// Read refreshes the Terraform state with the latest data.
+func (r *imageRepoResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	// Read the current state into the resource model.
+	var state imageRepoResourceModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	tflog.Info(ctx, fmt.Sprintf("read image repo request: %s", state.ID))
+
+	// Query for the repo to update state
+	id := state.ID.ValueString()
+	repoList, err := r.prov.client.Registry().Registry().ListRepos(ctx, &registry.RepoFilter{
+		Id: id,
+	})
+	if err != nil {
+		resp.Diagnostics.Append(errorToDiagnostic(err, "failed to list image repos"))
+		return
+	}
+
+	switch c := len(repoList.GetItems()); {
+	case c == 0:
+		// Repo doesn't exist or was deleted outside TF
+		resp.State.RemoveResource(ctx)
+		return
+	case c > 1:
+		resp.Diagnostics.AddError("internal error", fmt.Sprintf("fatal data corruption: id %s matched more than one image repo", id))
+		return
+	}
+
+	// Update the state with values returned from the API.
+	repo := repoList.GetItems()[0]
+	state.ID = types.StringValue(repo.Id)
+	state.ParentID = types.StringValue(uidp.Parent(repo.Id))
+	state.Name = types.StringValue(repo.Name)
+
+	var diags diag.Diagnostics
+	state.Bundles, diags = types.ListValueFrom(ctx, types.StringType, repo.Bundles)
+	if diags.HasError() {
+		resp.Diagnostics.Append(diags...)
+		return
+	}
+
+	// Set state
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+}
+
+// Update updates the resource and sets the updated Terraform state on success.
+func (r *imageRepoResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	// Read the plan into the resource model.
+	var data imageRepoResourceModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	tflog.Info(ctx, fmt.Sprintf("update image repo request: %s", data.ID))
+
+	bundles := make([]string, 0, len(data.Bundles.Elements()))
+	resp.Diagnostics.Append(data.Bundles.ElementsAs(ctx, &bundles, false /* allowUnhandled */)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	repo, err := r.prov.client.Registry().Registry().UpdateRepo(ctx, &registry.Repo{
+		Id:      data.ID.ValueString(),
+		Name:    data.Name.ValueString(),
+		Bundles: bundles,
+	})
+	if err != nil {
+		resp.Diagnostics.Append(errorToDiagnostic(err, "failed to update image repo"))
+		return
+	}
+
+	// Update the state with values returned from the API.
+	data.ID = types.StringValue(repo.Id)
+	data.Name = types.StringValue(repo.Name)
+
+	var diags diag.Diagnostics
+	data.Bundles, diags = types.ListValueFrom(ctx, types.StringType, repo.Bundles)
+	if diags.HasError() {
+		resp.Diagnostics.Append(diags...)
+		return
+	}
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+// Delete is purposefully a no-op so we don't accidentally delete repos with terraform
+// instead, we can delete them with "chainctl img rm"
+func (r *imageRepoResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	// When not running acceptance tests, add an error to resp so Terraform does not automatically remove this resource from state.
+	// See https://developer.hashicorp.com/terraform/plugin/framework/resources/delete#caveats for details.
+	if !r.prov.testing {
+		resp.Diagnostics.AddError("not implemented", "Image repos cannot be deleted through Terraform. Use `chainctl img repo rm` to manually delete.")
+		return
+	}
+
+	// Read the current state into the resource model.
+	var state imageRepoResourceModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	tflog.Info(ctx, fmt.Sprintf("ACCEPTANCE TEST: delete image repo request: %s", state.ID))
+
+	id := state.ID.ValueString()
+	_, err := r.prov.client.Registry().Registry().DeleteRepo(ctx, &registry.DeleteRepoRequest{
+		Id: id,
+	})
+	if err != nil {
+		resp.Diagnostics.Append(errorToDiagnostic(err, fmt.Sprintf("failed to delete image repo %q", id)))
+		return
+	}
+}

--- a/internal/provider/resource_image_repo_test.go
+++ b/internal/provider/resource_image_repo_test.go
@@ -1,0 +1,85 @@
+/*
+Copyright 2023 Chainguard, Inc.
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package provider
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+type testRepo struct {
+	parentID string
+	name     string
+	bundles  string
+}
+
+func TestImageRepo(t *testing.T) {
+	parentID := os.Getenv("TF_ACC_GROUP_ID")
+	name := "test-name"
+
+	original := testRepo{
+		parentID: parentID,
+		name:     name,
+		bundles:  `["a", "b", "c"]`,
+	}
+
+	update := testRepo{
+		parentID: parentID,
+		name:     name,
+		bundles:  `["x", "y", "z"]`,
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// Create and Read testing.
+			{
+				Config: testImageRepo(original),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(`chainguard_image_repo.example`, `parent_id`, parentID),
+					resource.TestCheckResourceAttr(`chainguard_image_repo.example`, `name`, name),
+					resource.TestCheckResourceAttr(`chainguard_image_repo.example`, `bundles.0`, "a"),
+					resource.TestCheckResourceAttr(`chainguard_image_repo.example`, `bundles.1`, "b"),
+					resource.TestCheckResourceAttr(`chainguard_image_repo.example`, `bundles.2`, "c"),
+				),
+			},
+
+			// ImportState testing.
+			{
+				ResourceName:      "chainguard_image_repo.example",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+
+			// Update and Read testing.
+			{
+				Config: testImageRepo(update),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(`chainguard_image_repo.example`, `parent_id`, parentID),
+					resource.TestCheckResourceAttr(`chainguard_image_repo.example`, `name`, name),
+					resource.TestCheckResourceAttr(`chainguard_image_repo.example`, `bundles.0`, "x"),
+					resource.TestCheckResourceAttr(`chainguard_image_repo.example`, `bundles.1`, "y"),
+					resource.TestCheckResourceAttr(`chainguard_image_repo.example`, `bundles.2`, "z"),
+				),
+			},
+		},
+	})
+}
+
+func testImageRepo(repo testRepo) string {
+	const tmpl = `
+resource "chainguard_image_repo" "example" {
+  parent_id   = %q
+  name        = %q
+  bundles     = %s
+}
+`
+	return fmt.Sprintf(tmpl, repo.parentID, repo.name, repo.bundles)
+}


### PR DESCRIPTION
- add `resource_image_repo` and acceptance tests
- rename `validators.RunFuncs` -> `ValidateStringFuncs` to better reflect its purpose and match the parameter type.
- replace `providerData.version string` with `providerData.testing bool` to avoid string comparisions; `version` was only used to know if the execution context is acceptance testing.