### PR TITLE
replace duplicated token logic with `token` pkg from `sdk`

### DIFF
--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -7,12 +7,9 @@ package provider
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"os"
-	"path/filepath"
 	"runtime"
-	"strings"
 
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
@@ -20,13 +17,16 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/provider"
 	"github.com/hashicorp/terraform-plugin-framework/provider/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
 	"chainguard.dev/sdk/pkg/auth"
+	sdktoken "chainguard.dev/sdk/pkg/auth/token"
 	"chainguard.dev/sdk/proto/platform"
+	"github.com/chainguard-dev/terraform-provider-chainguard/internal/validators"
 )
 
 const (
@@ -116,6 +116,9 @@ func (p *Provider) Schema(_ context.Context, _ provider.SchemaRequest, resp *pro
 			"console_api": schema.StringAttribute{
 				Optional:    true,
 				Description: "URL of Chainguard console API. Ensure a valid token has been generated for this URL with `chainctl auth login`.",
+				Validators: []validator.String{
+					validators.IsURL(false /* requireHTTPS */),
+				},
 			},
 		},
 	}
@@ -130,7 +133,6 @@ type providerData struct {
 func (p *Provider) Configure(ctx context.Context, req provider.ConfigureRequest, resp *provider.ConfigureResponse) {
 	var data ProviderModel
 	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
-	// TODO(colin): data validation
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -161,7 +163,7 @@ func (p *Provider) Configure(ctx context.Context, req provider.ConfigureRequest,
 	ctx = tflog.SetField(ctx, "chainguard.console_api", consoleAPI)
 	tflog.Info(ctx, "configuring chainguard client")
 
-	token, err := loadChainguardToken(audience)
+	token, err := sdktoken.Load(audience)
 	if err != nil {
 		resp.Diagnostics.AddAttributeError(
 			path.Root("console_api"),
@@ -209,42 +211,4 @@ func errorToDiagnostic(err error, summary string) diag.Diagnostic {
 			fmt.Sprintf("%s: %s", stat.Code(), stat.Message()))
 	}
 	return d
-}
-
-// The following functions cacheFilePath, loadChainguardToken, latestChainguardToken,
-// and getChainguardTokenLocation are copied from commands.go in chainctl
-
-// expandJoin takes the Chainguard config root, expands the path, and returns
-// the expanded path joined with the passed in file name.
-// expandJoin takes the Chainguard config root, expands the path, and returns
-// the expanded path joined with the passed in file name.
-func cacheFilePath(file string) (string, error) {
-	path, err := os.UserCacheDir()
-	if err != nil {
-		return "", err
-	}
-	path = filepath.Join(path, "chainguard", file)
-	if _, err := os.Stat(filepath.Dir(path)); errors.Is(err, os.ErrNotExist) {
-		if err := os.MkdirAll(filepath.Dir(path), os.ModePerm); err != nil {
-			return "", err
-		}
-	}
-	return path, nil
-}
-
-// loadChainguardToken loads the chainguard token from the configured cache directory.
-func loadChainguardToken(audience string) ([]byte, error) {
-	path, err := getChainguardTokenLocation(audience)
-	if err != nil {
-		return nil, err
-	}
-
-	return os.ReadFile(path)
-}
-
-func getChainguardTokenLocation(audience string) (string, error) {
-	// first, try to get a token specific to the audience
-	a := strings.ReplaceAll(audience, "/", "-")
-	fp := filepath.Join(a, chainguardTokenFilename)
-	return cacheFilePath(fp)
 }

--- a/internal/provider/resource_account_associations.go
+++ b/internal/provider/resource_account_associations.go
@@ -21,8 +21,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
-	"chainguard.dev/api/pkg/validation"
-	iam "chainguard.dev/api/proto/platform/iam/v1"
+	"chainguard.dev/sdk/pkg/validation"
+	iam "chainguard.dev/sdk/proto/platform/iam/v1"
 	"github.com/chainguard-dev/terraform-provider-chainguard/internal/validators"
 	"github.com/hashicorp/terraform-plugin-framework-validators/objectvalidator"
 )

--- a/internal/provider/resource_account_associations_test.go
+++ b/internal/provider/resource_account_associations_test.go
@@ -10,7 +10,7 @@ import (
 	"os"
 	"testing"
 
-	"chainguard.dev/api/pkg/uidp"
+	"chainguard.dev/sdk/pkg/uidp"
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )


### PR DESCRIPTION
Current terraform provider duplicated the Chainguard token loading logic from `chainctl`, before it was extracted to its own package in `sdk`. Now that `sdk/pkg/auth/token` is available, prefer that over duplication. 

Additionally, add HTTP validation to `console_api` provider attribute.