### PR TITLE
Fix identity test group check

### DIFF
--- a/internal/provider/resource_identity_test.go
+++ b/internal/provider/resource_identity_test.go
@@ -675,12 +675,9 @@ resource "chainguard_rolebinding" "binding" {
 					if err != nil {
 						return err
 					}
-					if len(gl.Items) != 1 {
-						ids := make([]string, 0, len(gl.Items))
-						for _, g := range gl.Items {
-							ids = append(ids, g.Id)
-						}
-						return fmt.Errorf("got %d groups, wanted 1: %s", len(gl.Items), strings.Join(ids, ", "))
+					// Tests are run in parallel in CI, so some leakage of groups between test instances is expected.
+					if len(gl.Items) < 1 {
+						return fmt.Errorf("got 0 groups, wanted at least 1")
 					}
 					g := gl.Items[0]
 					if g.Id != group {
@@ -751,12 +748,9 @@ resource "chainguard_rolebinding" "binding" {
 					if err != nil {
 						return err
 					}
-					if len(gl.Items) != 1 {
-						ids := make([]string, 0, len(gl.Items))
-						for _, g := range gl.Items {
-							ids = append(ids, g.Id)
-						}
-						return fmt.Errorf("got %d groups, wanted 1: %s", len(gl.Items), strings.Join(ids, ", "))
+					// Tests are run in parallel in CI, so some leakage of groups between test instances is expected.
+					if len(gl.Items) < 1 {
+						return fmt.Errorf("got 0 groups, wanted at least 1")
 					}
 					g := gl.Items[0]
 					if g.Id != group {
@@ -878,12 +872,9 @@ resource "chainguard_rolebinding" "binding" {
 					if err != nil {
 						return err
 					}
-					if len(gl.Items) != 1 {
-						ids := make([]string, 0, len(gl.Items))
-						for _, g := range gl.Items {
-							ids = append(ids, g.Id)
-						}
-						return fmt.Errorf("got %d groups, wanted 1: %s", len(gl.Items), strings.Join(ids, ", "))
+					// Tests are run in parallel in CI, so some leakage of groups between test instances is expected.
+					if len(gl.Items) < 1 {
+						return fmt.Errorf("got 0 groups, wanted at least 1")
 					}
 					g := gl.Items[0]
 					if g.Id != group {
@@ -1005,12 +996,9 @@ resource "chainguard_rolebinding" "binding" {
 					if err != nil {
 						return err
 					}
-					if len(gl.Items) != 1 {
-						ids := make([]string, 0, len(gl.Items))
-						for _, g := range gl.Items {
-							ids = append(ids, g.Id)
-						}
-						return fmt.Errorf("got %d groups, wanted 1: %s", len(gl.Items), strings.Join(ids, ", "))
+					// Tests are run in parallel in CI, so some leakage of groups between test instances is expected.
+					if len(gl.Items) < 1 {
+						return fmt.Errorf("got 0 groups, wanted at least 1")
 					}
 					g := gl.Items[0]
 					if g.Id != group {


### PR DESCRIPTION
Since tests are run in parallel in CI, there can be multiple subgroups within the `terraform-tests` group. The identity test failed when more than one group was found, even though this isn't really an error; they are just groups in-transit and are removed once the test finishes. 

Update the test so it checks for at least one group, which indicates a successful token exchange.