### PR TITLE
Fix terraform reporting updates when none happened

### DIFF
--- a/internal/provider/resource_policy.go
+++ b/internal/provider/resource_policy.go
@@ -75,8 +75,9 @@ func (r *policyResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 				Validators:    []validator.String{validators.UIDP(false /* allowRootSentinel */)},
 			},
 			"name": schema.StringAttribute{
-				Description: "Name of the policy",
-				Computed:    true,
+				Description:   "Name of the policy",
+				Computed:      true,
+				PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
 			},
 			"description": schema.StringAttribute{
 				Description: "Description of the policy",
@@ -157,7 +158,9 @@ func (r *policyResource) Read(ctx context.Context, req resource.ReadRequest, res
 		pol := polList.Items[0]
 		state.ID = types.StringValue(pol.Id)
 		state.Name = types.StringValue(pol.Name)
-		state.Description = types.StringValue(pol.Description)
+		if !(state.Description.IsNull() && pol.Description == "") {
+			state.Description = types.StringValue(pol.Description)
+		}
 		state.ParentID = types.StringValue(uidp.Parent(pol.Id))
 		state.Document = types.StringValue(pol.Document)
 


### PR DESCRIPTION
Due to Terraform types not equating null and empty values, Terraform will report an update is needed on a resource when nothing has changed (e.g. setting a null `description` attribute to `""` returned from the API). Similarly, if an object changes addresses but not values, it is reported as needing updated.

This PR fixes this drift issue by checking the state value vs returned API values before updating the state. For `chainguard_policy` use the previous state value for `policy.name` which is computed from `policy.document`. For `chainguard_identity_provider`, only create a new `oidc` block if any values have changed.