### PR TITLE
enable auto login by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,31 +12,25 @@ Configure the provider in your Terraform config:
 ```terraform
 terraform {
   required_providers {
-    chainguard = {
-      source = "chainguard-dev/chainguard"
-    }
+    chainguard = { source = "chainguard-dev/chainguard" }
   }
 }
-
-provider "chainguard" {}
 ```
 
-You can specify login options to enable automatic token refreshes if your Chainguard token is expired or missing.
+By default, the provider will attempt to refresh your Chainguard token when it's expired. You can disable this with:
 
 ```terraform
 provider "chainguard" {
   login_options {
-    enabled = true
+    disabled = true
   }
 }
 ```
 
 Additional options include specifying an identity to assume when authenticating and a verified organization name
-to use a custom identity provider rather than the Auth0 defaults (GitHub, GitLab, and Google). See `/examples/provider-login-options`
-for additional information.
+to use a custom identity provider rather than the Auth0 defaults (GitHub, GitLab, and Google).
 
-Detailed documentation on all available resources can be found under
-`/docs`.
+Detailed documentation on all available resources can be found under `/docs`.
 
 ## Developing the Provider
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -37,7 +37,7 @@ provider "chainguard" {
 Optional:
 
 - `auth0_connection` (String) Auth0 social connection to use by default for OIDC token. Must be one of: google-oauth2, gitlab, github
-- `enabled` (Boolean) Enabled automatic login when Chainguard token is expired.
+- `disabled` (Boolean) Disable automatic login when Chainguard token is expired.
 - `identity_id` (String) UIDP of the identity to assume when exchanging OIDC token for Chainguard token.
 - `identity_provider_id` (String) UIDP of the identity provider authenticate with for OIDC token.
 - `organization_name` (String) Verified organization name for determining identity provider to obtain OIDC token.

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -83,7 +83,7 @@ type ProviderModel struct {
 }
 
 type loginModel struct {
-	Enabled          types.Bool   `tfsdk:"enabled"`
+	Disabled         types.Bool   `tfsdk:"disabled"`
 	Identity         types.String `tfsdk:"identity_id"`
 	IdentityProvider types.String `tfsdk:"identity_provider_id"`
 	Auth0Connection  types.String `tfsdk:"auth0_connection"`
@@ -142,8 +142,8 @@ func (p *Provider) Schema(_ context.Context, _ provider.SchemaRequest, resp *pro
 			"login_options": schema.SingleNestedBlock{
 				Description: "Options to configure automatic login when Chainguard token is expired.",
 				Attributes: map[string]schema.Attribute{
-					"enabled": schema.BoolAttribute{
-						Description: "Enabled automatic login when Chainguard token is expired.",
+					"disabled": schema.BoolAttribute{
+						Description: "Disable automatic login when Chainguard token is expired.",
 						Optional:    true,
 					},
 					"identity_id": schema.StringAttribute{
@@ -213,7 +213,7 @@ func (p *Provider) Configure(ctx context.Context, req provider.ConfigureRequest,
 		tflog.Info(ctx, fmt.Sprintf("login options parsed: %#v", lm))
 	}
 
-	if (os.Getenv("TF_CHAINGUARD_LOGIN") != "" || lm.Enabled.ValueBool()) && sdktoken.RemainingLife(audience, time.Minute) <= 0 {
+	if (os.Getenv("TF_CHAINGUARD_LOGIN") != "" || !lm.Disabled.ValueBool()) && sdktoken.RemainingLife(audience, time.Minute) <= 0 {
 		tflog.Info(ctx, "launching login browser")
 		// Construct the issuer URL from the console API.
 		issuer := strings.Replace(consoleAPI, "console-api", "issuer", 1)


### PR DESCRIPTION
I don't think there's a way to make it `Enabled` which defaults to true (at least nothing I could figure out).

Instead, we can rename it to `Disabled` which defaults to false, and get the same effect.

This might cause state schema issues since the `Enabled` field is gone where it may have been previously set. If it does, it's incredibly unlikely that anybody but us is affected, and the solution is to blow away state, or at least blow away the offending part of state, and keep going.