### PR TITLE
Add `default_role` to identity providers

### DIFF
--- a/docs/resources/identity_provider.md
+++ b/docs/resources/identity_provider.md
@@ -17,6 +17,9 @@ resource "chainguard_identity_provider" "example" {
   parent_id   = "foo/bar"
   name        = "my customer idp"
   description = "for my team"
+  # The default role must be a built in role,
+  # or belong to the parent group or one of its ancestors.
+  default_role = "foo/bar/role-id"
   oidc {
     issuer            = "https://issuer.example.com"
     cliend_id         = "client id"
@@ -31,6 +34,7 @@ resource "chainguard_identity_provider" "example" {
 
 ### Required
 
+- `default_role` (String) The id of the role new users are bound to on first login.
 - `name` (String) The name of this identity provider.
 - `parent_id` (String) The group containing this identity provider.
 

--- a/examples/resources/chainguard_identity_provider/resource.tf
+++ b/examples/resources/chainguard_identity_provider/resource.tf
@@ -2,6 +2,9 @@ resource "chainguard_identity_provider" "example" {
   parent_id   = "foo/bar"
   name        = "my customer idp"
   description = "for my team"
+  # The default role must be a built in role,
+  # or belong to the parent group or one of its ancestors.
+  default_role = "foo/bar/role-id"
   oidc {
     issuer            = "https://issuer.example.com"
     cliend_id         = "client id"

--- a/internal/provider/resource_identity_provider.go
+++ b/internal/provider/resource_identity_provider.go
@@ -48,6 +48,7 @@ type identityProviderResourceModel struct {
 	ParentID    types.String `tfsdk:"parent_id"`
 	Name        types.String `tfsdk:"name"`
 	Description types.String `tfsdk:"description"`
+	DefaultRole types.String `tfsdk:"default_role"`
 	OIDC        types.Object `tfsdk:"oidc"`
 }
 
@@ -90,6 +91,11 @@ func (r *identityProviderResource) Schema(_ context.Context, _ resource.SchemaRe
 			"description": schema.StringAttribute{
 				Description: "A longer description of the purpose of this identity provider.",
 				Optional:    true,
+			},
+			"default_role": schema.StringAttribute{
+				Description: "The id of the role new users are bound to on first login.",
+				Required:    true,
+				Validators:  []validator.String{validators.UIDP(false /* allowRootSentinel */)},
 			},
 		},
 		Blocks: map[string]schema.Block{
@@ -148,6 +154,7 @@ func populateIDP(ctx context.Context, model *identityProviderResourceModel) (*ia
 		Id:          model.ID.ValueString(),
 		Name:        model.Name.ValueString(),
 		Description: model.Description.ValueString(),
+		DefaultRole: model.DefaultRole.ValueString(),
 	}
 
 	if !model.OIDC.IsNull() {
@@ -243,6 +250,7 @@ func (r *identityProviderResource) Read(ctx context.Context, req resource.ReadRe
 	state.ID = types.StringValue(idp.Id)
 	state.Name = types.StringValue(idp.Name)
 	state.Description = types.StringValue(idp.Description)
+	state.DefaultRole = types.StringValue(idp.DefaultRole)
 	state.ParentID = types.StringValue(uidp.Parent(idp.Id))
 
 	switch conf := idp.Configuration.(type) {

--- a/internal/provider/resource_identity_provider_test.go
+++ b/internal/provider/resource_identity_provider_test.go
@@ -26,6 +26,7 @@ type testIDP struct {
 	parentID    string
 	name        string
 	description string
+	defaultRole string
 	oidc        oidc
 }
 
@@ -34,6 +35,7 @@ func TestAccResourceIdentityProvider(t *testing.T) {
 		parentID:    os.Getenv("TF_ACC_GROUP_ID"),
 		name:        acctest.RandString(10),
 		description: acctest.RandString(10),
+		defaultRole: "data.chainguard_role.viewer_test.items[0].id",
 		oidc: oidc{
 			issuer:           "https://example.com",
 			clientID:         acctest.RandString(10),
@@ -46,6 +48,7 @@ func TestAccResourceIdentityProvider(t *testing.T) {
 		parentID:    os.Getenv("TF_ACC_GROUP_ID"),
 		name:        acctest.RandString(10),
 		description: acctest.RandString(10),
+		defaultRole: "data.chainguard_role.viewer_test.items[0].id",
 		oidc: oidc{
 			issuer:           "https://new.example.com",
 			clientID:         acctest.RandString(10),
@@ -61,7 +64,7 @@ func TestAccResourceIdentityProvider(t *testing.T) {
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccResourceIdentityProvider(original),
+				Config: accDataRoleViewer + testAccResourceIdentityProvider(original),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(`chainguard_identity_provider.example`, `parent_id`, original.parentID),
 					resource.TestCheckResourceAttr(`chainguard_identity_provider.example`, `name`, original.name),
@@ -79,7 +82,7 @@ func TestAccResourceIdentityProvider(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccResourceIdentityProvider(update),
+				Config: accDataRoleViewer + testAccResourceIdentityProvider(update),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(`chainguard_identity_provider.example`, `parent_id`, update.parentID),
 					resource.TestCheckResourceAttr(`chainguard_identity_provider.example`, `name`, update.name),
@@ -97,9 +100,10 @@ func TestAccResourceIdentityProvider(t *testing.T) {
 func testAccResourceIdentityProvider(idp testIDP) string {
 	const tmpl = `	
 resource "chainguard_identity_provider" "example" {
-  parent_id   = %q
-  name        = %q
-  description = %q
+  parent_id    = %q
+  name         = %q
+  description  = %q
+  default_role = %s
   oidc {
     issuer            = %q
     client_id         = %q
@@ -108,5 +112,5 @@ resource "chainguard_identity_provider" "example" {
   }
 }
 `
-	return fmt.Sprintf(tmpl, idp.parentID, idp.name, idp.description, idp.oidc.issuer, idp.oidc.clientID, idp.oidc.clientSecret, idp.oidc.additionalScopes)
+	return fmt.Sprintf(tmpl, idp.parentID, idp.name, idp.description, idp.defaultRole, idp.oidc.issuer, idp.oidc.clientID, idp.oidc.clientSecret, idp.oidc.additionalScopes)
 }


### PR DESCRIPTION
Add `default_role` attribute to identity providers and make it required. This is similar to the client-side requirement of setting up an idp through `chainctl`, even though it is not required on the server.