### PR TITLE
Use random resource names in tests

### DIFF
--- a/internal/provider/resource_image_repo_test.go
+++ b/internal/provider/resource_image_repo_test.go
@@ -10,8 +10,10 @@ import (
 	"os"
 	"testing"
 
-	"chainguard.dev/sdk/uidp"
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+
+	"chainguard.dev/sdk/uidp"
 )
 
 type testRepo struct {
@@ -25,7 +27,7 @@ type testRepo struct {
 
 func TestImageRepo(t *testing.T) {
 	parentID := os.Getenv("TF_ACC_GROUP_ID")
-	name := "test-name"
+	name := acctest.RandString(10)
 
 	original := testRepo{
 		parentID: parentID,

--- a/internal/provider/resource_image_tag_test.go
+++ b/internal/provider/resource_image_tag_test.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
 
@@ -21,7 +22,7 @@ type testTag struct {
 
 func TestImageTag(t *testing.T) {
 	parentID := os.Getenv("TF_ACC_GROUP_ID")
-	name := "test-name-for-tag"
+	name := acctest.RandString(10)
 
 	original := testTag{
 		parentID: parentID,


### PR DESCRIPTION
Attempt to fix test flakes by ensuring all acceptance tests are using random resource names to avoid collisions during parallel tests.