### PR TITLE
idp: remove setting ClientSecret from Read

### DIFF
--- a/internal/provider/resource_identity_provider.go
+++ b/internal/provider/resource_identity_provider.go
@@ -272,7 +272,6 @@ func (r *identityProviderResource) Read(ctx context.Context, req resource.ReadRe
 			}
 
 			update = (oidc.ClientID.ValueString() != conf.Oidc.ClientId) ||
-				(oidc.ClientSecret.ValueString() != conf.Oidc.ClientSecret) ||
 				(oidc.Issuer.ValueString() != conf.Oidc.Issuer) ||
 				(!oidc.AdditionalScopes.Equal(scopes))
 		}
@@ -280,7 +279,7 @@ func (r *identityProviderResource) Read(ctx context.Context, req resource.ReadRe
 		if update {
 			oidc.Issuer = types.StringValue(conf.Oidc.Issuer)
 			oidc.ClientID = types.StringValue(conf.Oidc.ClientId)
-			oidc.ClientSecret = types.StringValue(conf.Oidc.ClientSecret)
+			// ClientSecret is not returned by the API
 			oidc.AdditionalScopes = scopes
 			state.OIDC, diags = types.ObjectValueFrom(ctx, state.OIDC.AttributeTypes(ctx), oidc)
 			resp.Diagnostics.Append(diags...)

--- a/internal/provider/resource_identity_provider_test.go
+++ b/internal/provider/resource_identity_provider_test.go
@@ -77,9 +77,10 @@ func TestAccResourceIdentityProvider(t *testing.T) {
 			},
 			// ImportState testing.
 			{
-				ResourceName:      "chainguard_identity_provider.example",
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            "chainguard_identity_provider.example",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"oidc.client_secret"},
 			},
 			{
 				Config: accDataRoleViewer + testAccResourceIdentityProvider(update),


### PR DESCRIPTION
The API no longer returns `IdentityProvider.ClientSecret`. Remove overwriting the value in state since it will always be empty on `Read` to avoid reporting drift in state.