### PR TITLE
enable refresh tokens by default

### DIFF
--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -247,8 +247,12 @@ func (p *Provider) Configure(ctx context.Context, req provider.ConfigureRequest,
 			IdentityProvider: protoutil.FirstNonEmpty(os.Getenv("TF_CHAINGUARD_IDP"), lo.IdentityProvider.ValueString()),
 			OrgName:          protoutil.FirstNonEmpty(os.Getenv("TF_CHAINGUARD_ORG_NAME"), lo.OrgName.ValueString()),
 			UserAgent:        UserAgent,
-			UseRefreshTokens: protoutil.DefaultBool(lo.EnableRefreshTokens, false),
 		}
+
+		// Enable refresh tokens for users by default.
+		// NB: Refresh tokens are incompatible with assumable identities, and unnecessary
+		// when providing an explicit OIDC token.
+		cfg.UseRefreshTokens = protoutil.DefaultBool(lo.EnableRefreshTokens, cfg.IdentityID == "" && cfg.IdentityToken == "")
 
 		// Look for an OIDC token in the following places (in order of precedence)
 		// 1. TF_CHAINGUARD_IDENTITY_TOKEN env var


### PR DESCRIPTION
While refresh tokens were in development, we did not enable them in `tf-chainguard`. Now that they are stable, enable refresh tokens for users by default. If an assumable identity ID or explicit identity token is provided, do not enable them (refresh tokens are disallowed for use with assumable identities, and would be unnecessary for an explicit token)