### PR TITLE
add `verified` field to groups

### DIFF
--- a/docs/resources/group.md
+++ b/docs/resources/group.md
@@ -38,6 +38,7 @@ resource "chainguard_group" "example_sub" {
 
 - `description` (String) Description of this IAM group.
 - `parent_id` (String) Parent IAM group of this group. If not set, this group is assumed to be a root group.
+- `verified` (Boolean) Whether the organization has been verified by a Chainguardian. Only applicable to root groups.
 
 ### Read-Only
 


### PR DESCRIPTION
Add a `verified` field on `chainguard_group` resource. The identity running `terraform apply` will need to authorized to set this successfully.