### PR TITLE
use a constant for env overrides and plumb through nil cases better

### DIFF
--- a/docs/data-sources/versions.md
+++ b/docs/data-sources/versions.md
@@ -61,6 +61,7 @@ Read-Only:
 
 Read-Only:
 
+- `eol_broken` (Boolean) Whether the EOL version is broken.
 - `eol_date` (String) The eol date.
 - `exists` (Boolean) Whether the version exists.
 - `fips` (Boolean) Whether the FIPS version exists.

--- a/internal/provider/data_source_versions.go
+++ b/internal/provider/data_source_versions.go
@@ -143,6 +143,10 @@ func (d *versionsDataSource) Schema(_ context.Context, _ datasource.SchemaReques
 									Description: "The eol date.",
 									Computed:    true,
 								},
+								"eol_broken": schema.BoolAttribute{
+									Description: "Whether the EOL version is broken.",
+									Computed:    true,
+								},
 								"exists": schema.BoolAttribute{
 									Description: "Whether the version exists.",
 									Computed:    true,
@@ -343,8 +347,8 @@ func calculate(ctx context.Context, client registry.RegistryClient, pkg string, 
 		for _, v := range vproto.EolVersions {
 			if _, ok := allows[key+"-"+v.Version]; !ok {
 				diags.AddWarning(
-					fmt.Sprintf("CHAINGUARD_VERSION_ALLOW is set, skipping version %s-%s", key, v.Version),
-					fmt.Sprintf("%s-%s is not allowed by CHAINGUARD_VERSION_ALLOW [%v]", key, v.Version, allows),
+					fmt.Sprintf("%s is set, skipping version %s-%s", EnvChainguardVersionAllow, key, v.Version),
+					fmt.Sprintf("%s-%s is not allowed by %s [%v]", key, v.Version, EnvChainguardVersionAllow, allows),
 				)
 				continue
 			}
@@ -353,8 +357,8 @@ func calculate(ctx context.Context, client registry.RegistryClient, pkg string, 
 		for _, v := range vproto.Versions {
 			if _, ok := allows[key+"-"+v.Version]; !ok {
 				diags.AddWarning(
-					fmt.Sprintf("CHAINGUARD_VERSION_ALLOW is set, skipping eol version %s-%s", key, v.Version),
-					fmt.Sprintf("%s-%s is not allowed by CHAINGUARD_VERSION_ALLOW [%v]", key, v.Version, allows),
+					fmt.Sprintf("%s is set, skipping eol version %s-%s", EnvChainguardVersionAllow, key, v.Version),
+					fmt.Sprintf("%s-%s is not allowed by %s [%v]", key, v.Version, EnvChainguardVersionAllow, allows),
 				)
 				continue
 			}

--- a/internal/provider/data_source_versions.go
+++ b/internal/provider/data_source_versions.go
@@ -347,7 +347,7 @@ func calculate(ctx context.Context, client registry.RegistryClient, pkg string, 
 		for _, v := range vproto.EolVersions {
 			if _, ok := allows[key+"-"+v.Version]; !ok {
 				diags.AddWarning(
-					fmt.Sprintf("%s is set, skipping version %s-%s", EnvChainguardVersionAllow, key, v.Version),
+					fmt.Sprintf("%s is set, skipping eol version %s-%s", EnvChainguardVersionAllow, key, v.Version),
 					fmt.Sprintf("%s-%s is not allowed by %s [%v]", key, v.Version, EnvChainguardVersionAllow, allows),
 				)
 				continue
@@ -357,7 +357,7 @@ func calculate(ctx context.Context, client registry.RegistryClient, pkg string, 
 		for _, v := range vproto.Versions {
 			if _, ok := allows[key+"-"+v.Version]; !ok {
 				diags.AddWarning(
-					fmt.Sprintf("%s is set, skipping eol version %s-%s", EnvChainguardVersionAllow, key, v.Version),
+					fmt.Sprintf("%s is set, skipping version %s-%s", EnvChainguardVersionAllow, key, v.Version),
 					fmt.Sprintf("%s-%s is not allowed by %s [%v]", key, v.Version, EnvChainguardVersionAllow, allows),
 				)
 				continue

--- a/internal/provider/data_source_versions_test.go
+++ b/internal/provider/data_source_versions_test.go
@@ -267,6 +267,16 @@ func Test_calculate(t *testing.T) {
 				},
 			},
 		},
+		{
+			// NOTE: The provider Configure() doesn't set (is nil) when the allow
+			// list isn't set, so it isn't this test, this test simply protects
+			// against unknown regressions
+			name:                "empty but present allow list produces nothing",
+			pkg:                 "found",
+			allow:               map[string]struct{}{},
+			expectedOrderedKeys: []string{},
+			expectedVersionsMap: map[string]versionsDataSourceVersionMapModel{},
+		},
 	}
 
 	ctx := context.Background()


### PR DESCRIPTION
fixes a few things:

- inconsistent env var naming
- missing `eol_broken` definition causing panics (only appeared on certain positive hits)
- proper handling of `nil` version overrides