### PR TITLE
fix tests

### DIFF
--- a/docs/resources/image_repo.md
+++ b/docs/resources/image_repo.md
@@ -16,7 +16,7 @@ Image repo (note: delete is purposefully a no-op).
 resource "chainguard_image_repo" "example" {
   parent_id = "foo/bar"
   name      = "nginx"
-  bundles   = ["a", "b"]
+  bundles   = ["application", "fips"]
 }
 ```
 
@@ -31,7 +31,7 @@ resource "chainguard_image_repo" "example" {
 ### Optional
 
 - `aliases` (List of String) Known aliases for a given image.
-- `bundles` (List of String) List of bundles associated with this repo (a-z freeform keywords for sales purposes).
+- `bundles` (List of String) List of bundles associated with this repo (valid ones: `application|base|byol|ai|ai-gpu|featured|fips`).
 - `readme` (String) The README for this repo.
 - `sync_config` (Block, Optional) Configuration for catalog syncing. (see [below for nested schema](#nestedblock--sync_config))
 - `tier` (String) Image tier associated with this repo.

--- a/docs/resources/image_tag.md
+++ b/docs/resources/image_tag.md
@@ -30,7 +30,7 @@ resource "chainguard_image_tag" "example" {
 
 ### Optional
 
-- `bundles` (List of String) List of bundles associated with this repo (a-z freeform keywords for sales purposes).
+- `bundles` (List of String) List of bundles associated with this repo (valid ones: `application|base|byol|ai|ai-gpu|featured|fips`).
 
 ### Read-Only
 

--- a/examples/resources/chainguard_image_repo/resource.tf
+++ b/examples/resources/chainguard_image_repo/resource.tf
@@ -1,5 +1,5 @@
 resource "chainguard_image_repo" "example" {
   parent_id = "foo/bar"
   name      = "nginx"
-  bundles   = ["a", "b"]
+  bundles   = ["application", "fips"]
 }

--- a/internal/provider/resource_image_repo.go
+++ b/internal/provider/resource_image_repo.go
@@ -104,7 +104,7 @@ func (r *imageRepoResource) Schema(_ context.Context, _ resource.SchemaRequest, 
 			},
 
 			"bundles": schema.ListAttribute{
-				Description: "List of bundles associated with this repo (a-z freeform keywords for sales purposes).",
+				Description: "List of bundles associated with this repo (valid ones: `application|base|byol|ai|ai-gpu|featured|fips`).",
 				Optional:    true,
 				ElementType: types.StringType,
 				Validators: []validator.List{

--- a/internal/provider/resource_image_repo_test.go
+++ b/internal/provider/resource_image_repo_test.go
@@ -43,7 +43,7 @@ func TestImageRepo(t *testing.T) {
 	update1 := testRepo{
 		parentID: parentID,
 		name:     name,
-		bundles:  `["a", "b", "c"]`,
+		bundles:  `["application", "base", "fips"]`,
 		readme:   "# hello",
 		tier:     "APPLICATION",
 		aliases:  `["image:1", "image:2", "image:latest"]`,
@@ -53,7 +53,7 @@ func TestImageRepo(t *testing.T) {
 	update2 := testRepo{
 		parentID: parentID,
 		name:     name,
-		bundles:  `["x", "y", "z"]`,
+		bundles:  `["byol", "base", "featured"]`,
 		readme:   "# goodbye",
 		tier:     "BASE",
 		aliases:  `["image:97", "image:98", "image:99"]`,
@@ -107,9 +107,9 @@ func TestImageRepo(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(`chainguard_image_repo.example`, `parent_id`, parentID),
 					resource.TestCheckResourceAttr(`chainguard_image_repo.example`, `name`, name),
-					resource.TestCheckResourceAttr(`chainguard_image_repo.example`, `bundles.0`, "a"),
-					resource.TestCheckResourceAttr(`chainguard_image_repo.example`, `bundles.1`, "b"),
-					resource.TestCheckResourceAttr(`chainguard_image_repo.example`, `bundles.2`, "c"),
+					resource.TestCheckResourceAttr(`chainguard_image_repo.example`, `bundles.0`, "application"),
+					resource.TestCheckResourceAttr(`chainguard_image_repo.example`, `bundles.1`, "base"),
+					resource.TestCheckResourceAttr(`chainguard_image_repo.example`, `bundles.2`, "fips"),
 					resource.TestCheckResourceAttr(`chainguard_image_repo.example`, `readme`, "# hello"),
 					resource.TestCheckResourceAttr(`chainguard_image_repo.example`, `tier`, "APPLICATION"),
 					resource.TestCheckResourceAttr(`chainguard_image_repo.example`, `aliases.0`, "image:1"),
@@ -124,9 +124,9 @@ func TestImageRepo(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(`chainguard_image_repo.example`, `parent_id`, parentID),
 					resource.TestCheckResourceAttr(`chainguard_image_repo.example`, `name`, name),
-					resource.TestCheckResourceAttr(`chainguard_image_repo.example`, `bundles.0`, "x"),
-					resource.TestCheckResourceAttr(`chainguard_image_repo.example`, `bundles.1`, "y"),
-					resource.TestCheckResourceAttr(`chainguard_image_repo.example`, `bundles.2`, "z"),
+					resource.TestCheckResourceAttr(`chainguard_image_repo.example`, `bundles.0`, "byol"),
+					resource.TestCheckResourceAttr(`chainguard_image_repo.example`, `bundles.1`, "base"),
+					resource.TestCheckResourceAttr(`chainguard_image_repo.example`, `bundles.2`, "featured"),
 					resource.TestCheckResourceAttr(`chainguard_image_repo.example`, `readme`, "# goodbye"),
 					resource.TestCheckResourceAttr(`chainguard_image_repo.example`, `tier`, "BASE"),
 					resource.TestCheckResourceAttr(`chainguard_image_repo.example`, `aliases.0`, "image:97"),

--- a/internal/provider/resource_image_tag.go
+++ b/internal/provider/resource_image_tag.go
@@ -81,7 +81,7 @@ func (r *imageTagResource) Schema(_ context.Context, _ resource.SchemaRequest, r
 				},
 			},
 			"bundles": schema.ListAttribute{
-				Description: "List of bundles associated with this repo (a-z freeform keywords for sales purposes).",
+				Description: "List of bundles associated with this repo (valid ones: `application|base|byol|ai|ai-gpu|featured|fips`).",
 				Optional:    true,
 				ElementType: types.StringType,
 				Validators: []validator.List{

--- a/internal/provider/resource_image_tag_test.go
+++ b/internal/provider/resource_image_tag_test.go
@@ -27,13 +27,13 @@ func TestImageTag(t *testing.T) {
 	original := testTag{
 		parentID: parentID,
 		name:     name,
-		bundles:  `["aa", "bb", "cc"]`,
+		bundles:  `["application", "fips", "featured"]`,
 	}
 
 	update := testTag{
 		parentID: parentID,
 		name:     name,
-		bundles:  `["xx", "yy", "zz"]`,
+		bundles:  `["base", "application", "byol"]`,
 	}
 
 	resource.Test(t, resource.TestCase{
@@ -46,9 +46,9 @@ func TestImageTag(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					// We do not check the repo_id because it will be dynamic based on chainguard_image_repo.tag_example
 					resource.TestCheckResourceAttr(`chainguard_image_tag.tag_example`, `name`, name),
-					resource.TestCheckResourceAttr(`chainguard_image_tag.tag_example`, `bundles.0`, "aa"),
-					resource.TestCheckResourceAttr(`chainguard_image_tag.tag_example`, `bundles.1`, "bb"),
-					resource.TestCheckResourceAttr(`chainguard_image_tag.tag_example`, `bundles.2`, "cc"),
+					resource.TestCheckResourceAttr(`chainguard_image_tag.tag_example`, `bundles.0`, "application"),
+					resource.TestCheckResourceAttr(`chainguard_image_tag.tag_example`, `bundles.1`, "fips"),
+					resource.TestCheckResourceAttr(`chainguard_image_tag.tag_example`, `bundles.2`, "featured"),
 				),
 			},
 			// ImportState testing.
@@ -63,9 +63,9 @@ func TestImageTag(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					// We do not check the repo_id because it will be dynamic based on chainguard_image_repo.tag_example
 					resource.TestCheckResourceAttr(`chainguard_image_tag.tag_example`, `name`, name),
-					resource.TestCheckResourceAttr(`chainguard_image_tag.tag_example`, `bundles.0`, "xx"),
-					resource.TestCheckResourceAttr(`chainguard_image_tag.tag_example`, `bundles.1`, "yy"),
-					resource.TestCheckResourceAttr(`chainguard_image_tag.tag_example`, `bundles.2`, "zz"),
+					resource.TestCheckResourceAttr(`chainguard_image_tag.tag_example`, `bundles.0`, "base"),
+					resource.TestCheckResourceAttr(`chainguard_image_tag.tag_example`, `bundles.1`, "application"),
+					resource.TestCheckResourceAttr(`chainguard_image_tag.tag_example`, `bundles.2`, "byol"),
 				),
 			},
 		},


### PR DESCRIPTION
```
=== RUN   TestImageRepo
    resource_image_repo_test.go:80: Step 3/6 error: Error running pre-apply plan: exit status 1
        
        Error: failed string validation
        
          with chainguard_image_repo.example,
          on terraform_plugin_test.tf line 17, in resource "chainguard_image_repo" "example":
          17: resource "chainguard_image_repo" "example" {
        
        bundle item "a" is invalid: only the following keywords are valid
        "^application$|^base$|^byol$|^ai$|^ai-gpu$|^featured$|^fips$"
```

https://github.com/chainguard-dev/terraform-provider-chainguard/actions/runs/13139678918/job/36663536288


xref: https://github.com/chainguard-dev/sdk/blob/main/validation/bundles.go#L13