### PR TITLE
Protect unverifying a group with `verified_protection` field

### DIFF
--- a/docs/resources/group.md
+++ b/docs/resources/group.md
@@ -39,6 +39,7 @@ resource "chainguard_group" "example_sub" {
 - `description` (String) Description of this IAM group.
 - `parent_id` (String) Parent IAM group of this group. If not set, this group is assumed to be a root group.
 - `verified` (Boolean) Whether the organization has been verified by a Chainguardian. Only applicable to root groups.
+- `verified_protection` (Boolean) Prevent the group from being unverified through Terraform. Defaults to true.
 
 ### Read-Only
 


### PR DESCRIPTION
Inspired by [`deletion_protection` for GCP Cloud Run services](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/cloud_run_v2_service#deletion_protection-1), add a `verified_protection` field gates TF from unverifying a group. `verified_protection` defaults to `true` when not set, and must be explicitly set to `false` and applied to state before TF will be allowed to update a group from `verified = true` to `verified = [false|null]`