### PR TITLE
Fix `verified_protection` to work with existing groups

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ permissions: {}
 
 jobs:
   build:
-    name: Build
+    name: Build and Test
     runs-on: ubuntu-latest
     timeout-minutes: 5
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ permissions: {}
 
 jobs:
   build:
-    name: Build and Test
+    name: Build
     runs-on: ubuntu-latest
     timeout-minutes: 5
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,5 @@
 # Terraform Provider testing workflow.
-name: Tests
+name: Acceptance Tests
 
 on:
   push:

--- a/docs/resources/group.md
+++ b/docs/resources/group.md
@@ -39,7 +39,7 @@ resource "chainguard_group" "example_sub" {
 - `description` (String) Description of this IAM group.
 - `parent_id` (String) Parent IAM group of this group. If not set, this group is assumed to be a root group.
 - `verified` (Boolean) Whether the organization has been verified by a Chainguardian. Only applicable to root groups.
-- `verified_protection` (Boolean) Prevent the group from being unverified through Terraform. Defaults to true.
+- `verified_protection` (Boolean) Prevent the group from being unverified through Terraform. Null is treated as true.
 
 ### Read-Only
 

--- a/internal/provider/resource_group_test.go
+++ b/internal/provider/resource_group_test.go
@@ -11,8 +11,16 @@ import (
 	"regexp"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+
+	iam "chainguard.dev/sdk/proto/platform/iam/v1"
+	iamtest "chainguard.dev/sdk/proto/platform/iam/v1/test"
+	platformtest "chainguard.dev/sdk/proto/platform/test"
+	"github.com/chainguard-dev/clog/slogtest"
 )
 
 func testAccResourceGroup(parent, name, description string) string {
@@ -34,6 +42,178 @@ resource "chainguard_group" "test" {
 }
 `
 	return fmt.Sprintf(tmpl, name, description)
+}
+
+func TestGroupResource_update(t *testing.T) {
+	for _, c := range []struct {
+		name     string
+		onUpdate iamtest.GroupOnUpdate
+		data     groupResourceModel
+		state    groupResourceModel
+		wantDiag diag.Diagnostic
+	}{{
+		name: "update description",
+		onUpdate: iamtest.GroupOnUpdate{
+			Given: &iam.Group{
+				Id:          "id",
+				Name:        "name",
+				Description: "foo",
+				Verified:    false,
+			},
+			Updated: &iam.Group{
+				Id:          "id",
+				Name:        "name",
+				Description: "foo",
+				Verified:    false,
+			},
+		},
+		data: groupResourceModel{
+			ID:          types.StringValue("id"),
+			Name:        types.StringValue("name"),
+			Description: types.StringValue("foo"),
+		},
+		state: groupResourceModel{
+			ID:   types.StringValue("id"),
+			Name: types.StringValue("name"),
+		},
+	}, {
+		name: "set verified when null",
+		onUpdate: iamtest.GroupOnUpdate{
+			Given: &iam.Group{
+				Id:       "id",
+				Name:     "name",
+				Verified: true,
+			},
+			Updated: &iam.Group{
+				Id:       "id",
+				Name:     "name",
+				Verified: true,
+			},
+		},
+		data: groupResourceModel{
+			ID:       types.StringValue("id"),
+			Name:     types.StringValue("name"),
+			Verified: types.BoolValue(true),
+		},
+		state: groupResourceModel{
+			ID:   types.StringValue("id"),
+			Name: types.StringValue("name"),
+		},
+	}, {
+		name: "set verified when false",
+		onUpdate: iamtest.GroupOnUpdate{
+			Given: &iam.Group{
+				Id:       "id",
+				Name:     "name",
+				Verified: true,
+			},
+			Updated: &iam.Group{
+				Id:       "id",
+				Name:     "name",
+				Verified: true,
+			},
+		},
+		data: groupResourceModel{
+			ID:       types.StringValue("id"),
+			Name:     types.StringValue("name"),
+			Verified: types.BoolValue(true),
+		},
+		state: groupResourceModel{
+			ID:       types.StringValue("id"),
+			Name:     types.StringValue("name"),
+			Verified: types.BoolValue(false),
+		},
+	}, {
+		name: "unverify with verified_protection false",
+		onUpdate: iamtest.GroupOnUpdate{
+			Given: &iam.Group{
+				Id:       "id",
+				Name:     "name",
+				Verified: false,
+			},
+			Updated: &iam.Group{
+				Id:       "id",
+				Name:     "name",
+				Verified: false,
+			},
+		},
+		data: groupResourceModel{
+			ID:                 types.StringValue("id"),
+			Name:               types.StringValue("name"),
+			Verified:           types.BoolValue(false),
+			VerifiedProtection: types.BoolValue(false),
+		},
+		state: groupResourceModel{
+			ID:                 types.StringValue("id"),
+			Name:               types.StringValue("name"),
+			Verified:           types.BoolValue(true),
+			VerifiedProtection: types.BoolValue(false),
+		},
+	}, {
+		name: "unverify with verified_protection true",
+		data: groupResourceModel{
+			ID:                 types.StringValue("id"),
+			Name:               types.StringValue("name"),
+			Verified:           types.BoolValue(false),
+			VerifiedProtection: types.BoolValue(true),
+		},
+		state: groupResourceModel{
+			ID:                 types.StringValue("id"),
+			Name:               types.StringValue("name"),
+			Verified:           types.BoolValue(true),
+			VerifiedProtection: types.BoolValue(true),
+		},
+		wantDiag: diag.NewErrorDiagnostic("cannot unverify group", "group id is verified and verified_protection is true or null; apply verified_protection = false before attempting to unverify this group"),
+	}, {
+		name: "unverify with verified_protection null",
+		data: groupResourceModel{
+			ID:       types.StringValue("id"),
+			Name:     types.StringValue("name"),
+			Verified: types.BoolValue(false),
+		},
+		state: groupResourceModel{
+			ID:       types.StringValue("id"),
+			Name:     types.StringValue("name"),
+			Verified: types.BoolValue(true),
+		},
+		wantDiag: diag.NewErrorDiagnostic("cannot unverify group", "group id is verified and verified_protection is true or null; apply verified_protection = false before attempting to unverify this group"),
+	}} {
+		t.Run(c.name, func(t *testing.T) {
+			ctx := slogtest.Context(t)
+			r := &groupResource{
+				managedResource: managedResource{
+					prov: &providerData{
+						client: platformtest.MockPlatformClients{
+							IAMClient: iamtest.MockIAMClient{
+								GroupsClient: iamtest.MockGroupsClient{
+									OnUpdate: []iamtest.GroupOnUpdate{c.onUpdate},
+								},
+							},
+						},
+					},
+				},
+			}
+
+			dc := groupResourceModel{
+				ID:                 c.data.ID,
+				Name:               c.data.Name,
+				Description:        c.data.Description,
+				Verified:           c.data.Verified,
+				VerifiedProtection: c.data.VerifiedProtection,
+			}
+			gotDiag := r.update(ctx, &dc, c.state)
+			if (gotDiag == nil) != (c.wantDiag == nil) {
+				t.Fatalf("update did not return expected diagnostics: want=%v, got=%v", c.wantDiag, gotDiag)
+			}
+			if diff := cmp.Diff(c.wantDiag, gotDiag); diff != "" {
+				t.Fatalf("update did not return expected diagnostics (-want +got):\n%s", diff)
+			}
+			if diff := cmp.Diff(c.data, dc); diff != "" {
+				t.Fatalf("updated data not what expected (-want +got):\n%s", diff)
+			}
+		})
+	}
+
 }
 
 func TestAccGroupResource(t *testing.T) {


### PR DESCRIPTION
Using the built in `Default` value for `verified_protection` causes issues with existing groups since the plan ends up different. To avoid plan changes just from updating provider versions, make `verified_protection` an optional, nullable field and treat `null` like `true`.

Extract the `Update` business logic and add unit tests.