### PR TITLE
github: publish signing keys

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,6 +42,9 @@ jobs:
         with:
           gpg_private_key: ${{ steps.secrets.outputs.token }}
 
+      - run: |
+          gpg --keyserver keys.openpgp.org --send-keys ${{ steps.import_gpg.outputs.fingerprint }}
+
       - uses: goreleaser/goreleaser-action@9c156ee8a17a598857849441385a2041ef570552 # v6.3.0
         with:
           version: '~> v2'


### PR DESCRIPTION
Publish singing key to the public key signing servers for ease of
verification via Web-of-Trust.
