### PR TITLE
feat(azure) #617: add azure to account associations

### DIFF
--- a/docs/resources/account_associations.md
+++ b/docs/resources/account_associations.md
@@ -23,6 +23,13 @@ resource "chainguard_account_associations" "example" {
     project_id     = "example"
     project_number = "213411233"
   }
+  azure {
+    tenant_id = "12345678-1234-1234-1234-123456789012"
+    client_ids = {
+      "client1" = "11111111-1111-1111-1111-111111111111"
+      "client2" = "22222222-2222-2222-2222-222222222222"
+    }
+  }
 }
 ```
 
@@ -37,6 +44,7 @@ resource "chainguard_account_associations" "example" {
 ### Optional
 
 - `amazon` (Block, Optional) Amazon account configuration (see [below for nested schema](#nestedblock--amazon))
+- `azure` (Block, Optional) Azure account association configuration (see [below for nested schema](#nestedblock--azure))
 - `chainguard` (Block, Optional) Association of Chainguard services to the service principals they should assume when talking to Chainguard APIs. (see [below for nested schema](#nestedblock--chainguard))
 - `description` (String) Description of the account association.
 - `google` (Block, Optional) Google Cloud Platform account association configuration (see [below for nested schema](#nestedblock--google))
@@ -51,6 +59,15 @@ resource "chainguard_account_associations" "example" {
 Optional:
 
 - `account` (String) AWS account ID
+
+
+<a id="nestedblock--azure"></a>
+### Nested Schema for `azure`
+
+Optional:
+
+- `client_ids` (Map of String) Azure compoment name to client id mapping
+- `tenant_id` (String) Azure tenant id
 
 
 <a id="nestedblock--chainguard"></a>

--- a/examples/resources/chainguard_account_associations/resource.tf
+++ b/examples/resources/chainguard_account_associations/resource.tf
@@ -8,4 +8,11 @@ resource "chainguard_account_associations" "example" {
     project_id     = "example"
     project_number = "213411233"
   }
+  azure {
+    tenant_id = "12345678-1234-1234-1234-123456789012"
+    client_ids = {
+      "client1" = "11111111-1111-1111-1111-111111111111"
+      "client2" = "22222222-2222-2222-2222-222222222222"
+    }
+  }
 }


### PR DESCRIPTION
Add azure to account associations in Chainguard Terraform provider.

Part of [Issue 617](https://github.com/chainguard-dev/mono/issues/617)

### Testing

#### Single Group

Performing a terraform apply on [this branch](https://github.com/chainguard-dev/terraform-azure-chainguard-account-association/pull/1/) for `examples/basic` with only a small edit:
```
+provider "chainguard" {
+  console_api = "https://console-api.zcrosley.dev"
+}
+

 module "account_association" {
   source = "./../../"
+  environment = "zcrosley.dev"
+  resource_group = "tf-test-group"
```
This version on the module results in successful deployment of managed identities to Azure, configuring azure connection in chainguard:

```
{
  "items": [
    {
      "group": "61ec87e8534572139dae867941882200d3e89278",
      "amazon": null,
      "google": null,
      "github": null,
      "chainguard": null,
      "azure": {
        "tenantId": "32b8c550-a021-45aa-b9ba-66ccba087fea",
        "clientIds": {
          "canary": "35532c1d-5243-41e9-b4fd-5d349513fd6c",
          "catalog-syncer": "8af460bd-4a3e-4623-a870-c366fd27d658"
        }
      },
      "name": "example",
      "description": ""
    },
    ...
  ]
}
```
and azure impersonation works:
```
➜ curl -H "Authorization: Bearer $(cdev auth token)" -d '{"accountType":"AZURE"}' -X POST https://console-api.zcrosley.dev/iam/v1/account_associations/61ec87e8534572139dae867941882200d3e89278:check
{"ready":"Ready","reason":"","message":""}%
```

#### Multiple Groups

Performing a terraform apply on [this branch](https://github.com/chainguard-dev/terraform-azure-chainguard-account-association/pull/1/) for `examples/multiple-group-ids` with only a small edit:
```
+provider "chainguard" {
+  console_api = "https://console-api.zcrosley.dev"
+}
+

 module "account_association" {
   source = "./../../"
+  environment = "zcrosley.dev"
+  resource_group = "tf-test-group"
```
This version on the module results in successful deployment of managed identities to Azure, configuring azure connection in chainguard:

```
{
  "items": [
    {
      "group": "34f1bf959716e2ed94e199019642d2566a7118ae",
      "amazon": null,
      "google": null,
      "github": null,
      "chainguard": null,
      "azure": {
        "tenantId": "32b8c550-a021-45aa-b9ba-66ccba087fea",
        "clientIds": {
          "canary": "715ed083-dc59-4891-9181-fc924a1a48b2",
          "catalog-syncer": "aaf1fbb8-94b2-422b-8037-ecf085990720"
        }
      },
      "name": "example 2",
      "description": ""
    },
    {
      "group": "5b0be09d479f71d87926d99ba26931ef7bff13c4",
      "amazon": null,
      "google": null,
      "github": null,
      "chainguard": null,
      "azure": {
        "tenantId": "32b8c550-a021-45aa-b9ba-66ccba087fea",
        "clientIds": {
          "canary": "715ed083-dc59-4891-9181-fc924a1a48b2",
          "catalog-syncer": "aaf1fbb8-94b2-422b-8037-ecf085990720"
        }
      },
      "name": "example 1",
      "description": ""
    },
    ...
  ]
}
```
and azure impersonation works for both:
```
➜ curl -H "Authorization: Bearer $(cdev auth token)" -d '{"accountType":"AZURE"}' -X POST https://console-api.zcrosley.dev/iam/v1/account_associations/34f1bf959716e2ed94e199019642d2566a7118ae:check
{"ready":"Ready","reason":"","message":""}%

➜ curl -H "Authorization: Bearer $(cdev auth token)" -d '{"accountType":"AZURE"}' -X POST https://console-api.zcrosley.dev/iam/v1/account_associations/5b0be09d479f71d87926d99ba26931ef7bff13c4:check
{"ready":"Ready","reason":"","message":""}%
```