### PR TITLE
Don't make sync_config.expiration required.

### DIFF
--- a/internal/provider/resource_image_repo.go
+++ b/internal/provider/resource_image_repo.go
@@ -140,7 +140,6 @@ func (r *imageRepoResource) Schema(_ context.Context, _ resource.SchemaRequest, 
 				Validators: []validator.Object{
 					objectvalidator.AlsoRequires(
 						path.Root("sync_config").AtName("source").Expression(),
-						path.Root("sync_config").AtName("expiration").Expression(),
 					),
 				},
 				Attributes: map[string]schema.Attribute{


### PR DESCRIPTION
This isn't required, and the server should set this in most cases.