### PR TITLE
Relax repo source constraint

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,7 +62,24 @@ jobs:
           terraform_wrapper: false
 
       - run: go mod download
-      - env:
+
+      - name: Build provider
+        run: go build -o terraform-provider-chainguard
+
+      - name: Setup Terraform dev overrides
+        run: |
+          cat > ~/.terraformrc << EOF
+          provider_installation {
+            dev_overrides {
+              "chainguard-dev/chainguard" = "${{ github.workspace }}"
+            }
+            direct {}
+          }
+          EOF
+          terraform init
+
+      - name: Run acceptance tests
+        env:
           TF_ACC: "1"
           TF_ACC_GROUP_ID: "ef127a7c0909329f04b43d845cf80eea4247a07b/66305475446bbef6/51be6000f74f6cb7"
           TF_CHAINGUARD_IDENTITY: "ef127a7c0909329f04b43d845cf80eea4247a07b/66305475446bbef6/51be6000f74f6cb7/72b16b9edc62a069"

--- a/docs/resources/image_repo.md
+++ b/docs/resources/image_repo.md
@@ -52,7 +52,7 @@ Optional:
 - `expiration` (String) The RFC3339 encoded date and time at which this entitlement will expire.
 - `google` (String) The Google repository under which to create a new repository with the same name as the source repository.
 - `grace_period` (Boolean) Controls whether the image grace period functionality is enabled or not.
-- `source` (String) The UIDP of the repository to sync images from.
+- `source` (String) The source repository to sync images from.
 
 Read-Only:
 


### PR DESCRIPTION
This can accept human readable names (e.g. `static`).

We recently made a change that makes the source field more restrictive (previously it would let you put any repo you had access to, even though any non-catalog repos would be no-ops). Because of this, trimmed all catalog syncing related tests from the acceptance tests, since this is not something we can easily test anymore with the privileged test account.