### PR TITLE
Fix sync_config drift causing 'setting sync_config.expiration is not allowed' error

### DIFF
--- a/docs/resources/image_repo.md
+++ b/docs/resources/image_repo.md
@@ -49,9 +49,9 @@ Optional:
 - `amazon` (String) The Amazon repository under which to create a new repository with the same name as the source repository.
 - `apko_overlay` (String) A json-encoded APKO configuration to overlay on rebuilds of images being synced.
 - `azure` (String) The Azure repository under which to create a new repository with the same name as the source repository.
-- `expiration` (String) The RFC3339 encoded date and time at which this entitlement will expire.
+- `expiration` (String) The RFC3339 encoded date and time at which this entitlement will expire. Computed by API if not provided.
 - `google` (String) The Google repository under which to create a new repository with the same name as the source repository.
-- `grace_period` (Boolean) Controls whether the image grace period functionality is enabled or not.
+- `grace_period` (Boolean) Controls whether the image grace period functionality is enabled or not. Defaults to false if not provided.
 - `source` (String) The source repository to sync images from.
 
 Read-Only:


### PR DESCRIPTION
attempted fix for https://github.com/chainguard-dev/customer-issues/issues/2827

- mark `expiration`, `grace_period`, `unique_tags` as `Computed: true`
- add null checks in Create/Update to only send user-provided values
- populate all computed fields from API response after creation

my theory here is that https://github.com/chainguard-dev/terraform-provider-chainguard/commit/02b23c4556bee753e3d4e628ae75f0fb93ae29fc made expiration optional, but in a way that is causing Read() to update state with API-returned expiration, triggering drift detection, which then fails on Update() because API doesn't allow regular users to set expiration

tl;dr terraform detects drift where there shouldn't be any on update of resources. This attempts to stop this from happening