### PR TITLE
Fix regression: preserve user-provided sync_config.source value

### DIFF
--- a/internal/provider/resource_image_repo.go
+++ b/internal/provider/resource_image_repo.go
@@ -335,7 +335,8 @@ func (r *imageRepoResource) Create(ctx context.Context, req resource.CreateReque
 			resp.Diagnostics.Append(diags...)
 			return
 		}
-		cfg.Source = types.StringValue(repo.SyncConfig.Source)
+		// Populate computed fields from API response
+		// Note: Source is NOT populated here to avoid overwriting user input
 		cfg.Expiration = types.StringValue(repo.SyncConfig.Expiration.AsTime().Format(time.RFC3339))
 		cfg.UniqueTags = types.BoolValue(repo.SyncConfig.UniqueTags)
 		cfg.GracePeriod = types.BoolValue(repo.SyncConfig.GracePeriod)


### PR DESCRIPTION
the previous PR mistakenly included sources as a field to be populated from the API

https://github.com/chainguard-dev/customer-issues/issues/2827