### PR TITLE
fix: preserve user-provided source in sync_config during Read

### DIFF
--- a/internal/provider/resource_image_repo.go
+++ b/internal/provider/resource_image_repo.go
@@ -418,7 +418,9 @@ func (r *imageRepoResource) Read(ctx context.Context, req resource.ReadRequest, 
 			(sc.GracePeriod.ValueBool() != repo.SyncConfig.GracePeriod)
 
 		if update {
-			sc.Source = types.StringValue(repo.SyncConfig.Source)
+			// Don't overwrite Source - preserve user's input (friendly names like "nginx")
+			// The API accepts both friendly names and UIDPs, and we should maintain what
+			// the user declared in their config, not what the API returns internally.
 			if apiExpiration != "" {
 				sc.Expiration = types.StringValue(apiExpiration)
 			} else {


### PR DESCRIPTION
This fixes a regression where running terraform apply twice on an image_repo resource with sync_config would fail with the error `InvalidArgument: setting sync_config.expiration is not allowed`.

The issue stems from an inconsistency in how we handle the source field across our CRUD operations. When a user provides a friendly name like `nginx` in their terraform config, the Chainguard API accepts it during creation but internally resolves it to a UIDP identifier. On subsequent Read operations, the API returns this UIDP rather than the original friendly name.

The `Read` function was overwriting the user's friendly name with this internal UIDP in the terraform state. This caused terraform to detect drift on the next plan, seeing the config's `nginx` didn't match the state's UIDP value. When drift is detected in any `sync_config` field, terraform tries to reconcile all the fields in that block, including computed fields like expiration, `grace_period`, and `unique_tags`. The API correctly rejects attempts to set the expiration field on updates since it's meant to be managed server-side, leading to the error customers were seeing.

We already fixed this pattern in the `Create` function with PR #399, where we deliberately preserve the user's source input rather than overwriting it with what the API returns. The Update function also correctly uses the source value from the user's plan. This commit brings the `Read` function in line with that same approach, completing the consistency across all CRUD operations.

The API is designed to accept both friendly names and UIDPs for the source field, so there's no functional reason to normalize to UIDPs in our state. By preserving what the user declared, we maintain terraform's idempotency principle where applying the same configuration multiple times should produce the same result without drift.

With this change, the second terraform apply will see no drift in the `sync_config` block, won't attempt an update, and will complete successfully. The computed fields like expiration remain properly managed by the API, and users can continue to use the more readable friendly names in their configurations.