### PR TITLE
fix(tests): remove ExpectNonEmptyPlan from repo and tag tests

### DIFF
--- a/internal/provider/resource_image_repo_test.go
+++ b/internal/provider/resource_image_repo_test.go
@@ -87,11 +87,8 @@ func TestImageRepo(t *testing.T) {
 			},
 
 			// Update and Read testing. (1)
-			// ExpectNonEmptyPlan: the UpdateRepo API may not echo back all fields,
-			// causing the refresh plan to show drift for bundles/aliases/active_tags.
 			{
-				Config:             testImageRepo(update1),
-				ExpectNonEmptyPlan: true,
+				Config: testImageRepo(update1),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(`chainguard_image_repo.example`, `parent_id`, parentID),
 					resource.TestCheckResourceAttr(`chainguard_image_repo.example`, `name`, name),
@@ -111,8 +108,7 @@ func TestImageRepo(t *testing.T) {
 
 			// Update and Read testing. (2)
 			{
-				Config:             testImageRepo(update2),
-				ExpectNonEmptyPlan: true,
+				Config: testImageRepo(update2),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(`chainguard_image_repo.example`, `parent_id`, parentID),
 					resource.TestCheckResourceAttr(`chainguard_image_repo.example`, `name`, name),

--- a/internal/provider/resource_image_tag_test.go
+++ b/internal/provider/resource_image_tag_test.go
@@ -60,11 +60,8 @@ func TestImageTag(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			// Update and Read testing.
-			// ExpectNonEmptyPlan is set because computed fields (digest, last_updated)
-			// legitimately change on every update and show as (known after apply) in the plan.
 			{
-				Config:             testImageTag(update),
-				ExpectNonEmptyPlan: true,
+				Config: testImageTag(update),
 				Check: resource.ComposeTestCheckFunc(
 					// We do not check the repo_id because it will be dynamic based on chainguard_image_repo.tag_example
 					resource.TestCheckResourceAttr(`chainguard_image_tag.tag_example`, `name`, name),


### PR DESCRIPTION
### What

Remove `ExpectNonEmptyPlan: true` from the `TestImageRepo` and `TestImageTag` acceptance tests. The registry API now correctly returns `bundles`, `aliases`, and `active_tags` after mutations, so there is no longer post-refresh drift.

### Why

The registry datastore caching layer was updated in [mono#35740](https://github.com/chainguard-dev/mono/pull/35740) (March 30) to evict cached queries on CRUD operations. Previously, `ListRepos` / `ListTags` returned stale cached results (missing these fields) after an update, causing expected plan drift. With proper cache eviction, the refresh plan is now empty, and the `ExpectNonEmptyPlan: true` assertion fails.

### Notes

The defensive guards in the resource `Update` methods (`if len(repo.Bundles) > 0`) are now unnecessary but harmless — left in place to keep this change minimal.