### PR TITLE
fix: bump SDK to v0.1.53, adapt GitHub account associations to 1:N:M model

### DIFF
--- a/docs/resources/account_associations.md
+++ b/docs/resources/account_associations.md
@@ -47,7 +47,8 @@ resource "chainguard_account_associations" "example" {
 - `azure` (Block, Optional) Azure account association configuration (see [below for nested schema](#nestedblock--azure))
 - `chainguard` (Block, Optional) Association of Chainguard services to the service principals they should assume when talking to Chainguard APIs. (see [below for nested schema](#nestedblock--chainguard))
 - `description` (String) Description of the account association.
-- `github` (Block, Optional) GitHub App installation configuration (see [below for nested schema](#nestedblock--github))
+- `github` (Block, Optional, Deprecated) GitHub App installation configuration (deprecated: use github_installation instead). (see [below for nested schema](#nestedblock--github))
+- `github_installation` (Block List) GitHub App installation associations. Each block associates one (app_id, installation_id) pair with this group. Supports multiple installations. (see [below for nested schema](#nestedblock--github_installation))
 - `google` (Block, Optional) Google Cloud Platform account association configuration (see [below for nested schema](#nestedblock--google))
 
 ### Read-Only
@@ -84,13 +85,26 @@ Optional:
 
 Optional:
 
+- `app_id` (Number) GitHub App ID.
 - `installation_id` (Number) GitHub App Installation ID.
 - `name` (String) GitHub user/org name the installation is installed on.
 
 Read-Only:
 
+- `host` (String, Deprecated) Deprecated: no longer populated by the API.
+
+
+<a id="nestedblock--github_installation"></a>
+### Nested Schema for `github_installation`
+
+Required:
+
 - `app_id` (Number) GitHub App ID.
-- `host` (String) GitHub hostname the app is associated with.
+- `installation_id` (Number) GitHub App Installation ID.
+
+Optional:
+
+- `name` (String) GitHub user/org name the installation is installed on.
 
 
 <a id="nestedblock--google"></a>

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.25.7
 
 require (
 	chainguard.dev/apko v1.2.3
-	chainguard.dev/sdk v0.1.52
+	chainguard.dev/sdk v0.1.53
 	github.com/chainguard-dev/clog v1.8.0
 	github.com/coreos/go-oidc/v3 v3.17.0
 	github.com/google/go-cmp v0.7.0
@@ -22,7 +22,7 @@ require (
 )
 
 require (
-	chainguard.dev/go-grpc-kit v0.17.16 // indirect
+	chainguard.dev/go-grpc-kit v0.17.17 // indirect
 	cloud.google.com/go/auth v0.20.0 // indirect
 	cloud.google.com/go/auth/oauth2adapt v0.2.8 // indirect
 	cloud.google.com/go/compute/metadata v0.9.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,11 +1,11 @@
 chainguard.dev/apko v1.2.3 h1:VW6Xf5Xy3pB5FkE0EYMU9JvaeGE+nY/ix2F+pLbI2t8=
 chainguard.dev/apko v1.2.3/go.mod h1:yZ4odDgm5O3fp4CSw6SoToCbbfjMvznnIkJi+IJfVPw=
-chainguard.dev/go-grpc-kit v0.17.16 h1:Y9RKwZCnrYR3S0K8BiazyOoBrZF+Q7bJWDacfKXz2zg=
-chainguard.dev/go-grpc-kit v0.17.16/go.mod h1:0vrfIBJguXNa+EKOUEhx1Fj2aBp8o6A8gAHoidiF8ps=
+chainguard.dev/go-grpc-kit v0.17.17 h1:Jwhc0zyUwQbC2hNcsi+YMeUX/JUnM+dXVCkTw6wtPzs=
+chainguard.dev/go-grpc-kit v0.17.17/go.mod h1:qn0meP6RtrbLicE1bgBZnnVU9dvX95eLs0x0T6kZ+b4=
 chainguard.dev/go-oidctest v0.4.0 h1:B9YTfoa1WtsrEg0wnFeSP7i9tth0LO+GICm2j8HOgWI=
 chainguard.dev/go-oidctest v0.4.0/go.mod h1:IIic4S3je1I7Acy3bqPtaSPefGEsQDzUp7NJF35MPV4=
-chainguard.dev/sdk v0.1.52 h1:G1wmZHU8v5E78YlCHuwQH0Hwt4NBBCvCNAFad5FUanQ=
-chainguard.dev/sdk v0.1.52/go.mod h1:IZIiUyuNaxTao6mpC/BROsw/dwjl/DmCR/raIT7eK4c=
+chainguard.dev/sdk v0.1.53 h1:kfBtwMWe4jxDr9nXs/WMjRkaueWppSmYdNRMLSiMiTU=
+chainguard.dev/sdk v0.1.53/go.mod h1:mmbqrcm0E0dBSu7R130O2u029A8DTdf5GuGVNisCWw0=
 cloud.google.com/go/auth v0.20.0 h1:kXTssoVb4azsVDoUiF8KvxAqrsQcQtB53DcSgta74CA=
 cloud.google.com/go/auth v0.20.0/go.mod h1:942/yi/itH1SsmpyrbnTMDgGfdy2BUqIKyd0cyYLc5Q=
 cloud.google.com/go/auth/oauth2adapt v0.2.8 h1:keo8NaayQZ6wimpNSmW5OPc283g65QNIiLpZnkHRbnc=

--- a/internal/provider/resource_account_associations.go
+++ b/internal/provider/resource_account_associations.go
@@ -8,6 +8,8 @@ package provider
 import (
 	"context"
 	"fmt"
+	"maps"
+	"slices"
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/mapvalidator"
 
@@ -46,15 +48,16 @@ type accountAssociationsResource struct {
 }
 
 type accountAssociationsResourceModel struct {
-	ID          types.String `tfsdk:"id"`
-	Name        types.String `tfsdk:"name"`
-	Description types.String `tfsdk:"description"`
-	Group       types.String `tfsdk:"group"`
-	Amazon      types.Object `tfsdk:"amazon"`
-	Google      types.Object `tfsdk:"google"`
-	Azure       types.Object `tfsdk:"azure"`
-	Chainguard  types.Object `tfsdk:"chainguard"`
-	Github      types.Object `tfsdk:"github"`
+	ID                 types.String               `tfsdk:"id"`
+	Name               types.String               `tfsdk:"name"`
+	Description        types.String               `tfsdk:"description"`
+	Group              types.String               `tfsdk:"group"`
+	Amazon             types.Object               `tfsdk:"amazon"`
+	Google             types.Object               `tfsdk:"google"`
+	Azure              types.Object               `tfsdk:"azure"`
+	Chainguard         types.Object               `tfsdk:"chainguard"`
+	Github             types.Object               `tfsdk:"github"`
+	GithubInstallation []*githubInstallationModel `tfsdk:"github_installation"`
 }
 
 type amazonAccountModel struct {
@@ -77,6 +80,12 @@ type azureAccountModel struct {
 
 type githubAccountModel struct {
 	Host           types.String `tfsdk:"host"`
+	AppID          types.Int64  `tfsdk:"app_id"`
+	InstallationID types.Int64  `tfsdk:"installation_id"`
+	Name           types.String `tfsdk:"name"`
+}
+
+type githubInstallationModel struct {
 	AppID          types.Int64  `tfsdk:"app_id"`
 	InstallationID types.Int64  `tfsdk:"installation_id"`
 	Name           types.String `tfsdk:"name"`
@@ -133,6 +142,7 @@ func (r *accountAssociationsResource) Schema(_ context.Context, _ resource.Schem
 						path.MatchRoot("azure"),
 						path.MatchRoot("chainguard"),
 						path.MatchRoot("github"),
+						path.MatchRoot("github_installation"),
 					),
 				},
 				Attributes: map[string]schema.Attribute{
@@ -203,19 +213,26 @@ func (r *accountAssociationsResource) Schema(_ context.Context, _ resource.Schem
 				},
 			},
 			"github": schema.SingleNestedBlock{
-				Description: "GitHub App installation configuration",
+				DeprecationMessage: "Use github_installation blocks instead. This block supports only a single installation.",
+				Description:        "GitHub App installation configuration (deprecated: use github_installation instead).",
 				Validators: []validator.Object{
 					objectvalidator.AlsoRequires(
+						path.Root("github").AtName("app_id").Expression(),
 						path.Root("github").AtName("installation_id").Expression(),
+					),
+					objectvalidator.ConflictsWith(
+						path.MatchRoot("github_installation"),
 					),
 				},
 				Attributes: map[string]schema.Attribute{
 					"host": schema.StringAttribute{
-						Description: "GitHub hostname the app is associated with.",
-						Computed:    true,
+						Description:        "Deprecated: no longer populated by the API.",
+						DeprecationMessage: "This field is no longer populated and will be removed in a future version.",
+						Computed:           true,
 					},
 					"app_id": schema.Int64Attribute{
 						Description: "GitHub App ID.",
+						Optional:    true,
 						Computed:    true,
 					},
 					"installation_id": schema.Int64Attribute{
@@ -225,6 +242,25 @@ func (r *accountAssociationsResource) Schema(_ context.Context, _ resource.Schem
 					"name": schema.StringAttribute{
 						Description: "GitHub user/org name the installation is installed on.",
 						Optional:    true,
+					},
+				},
+			},
+			"github_installation": schema.ListNestedBlock{
+				Description: "GitHub App installation associations. Each block associates one (app_id, installation_id) pair with this group. Supports multiple installations.",
+				NestedObject: schema.NestedBlockObject{
+					Attributes: map[string]schema.Attribute{
+						"app_id": schema.Int64Attribute{
+							Description: "GitHub App ID.",
+							Required:    true,
+						},
+						"installation_id": schema.Int64Attribute{
+							Description: "GitHub App Installation ID.",
+							Required:    true,
+						},
+						"name": schema.StringAttribute{
+							Description: "GitHub user/org name the installation is installed on.",
+							Optional:    true,
+						},
 					},
 				},
 			},
@@ -289,10 +325,37 @@ func populateAccountAssociation(ctx context.Context, m accountAssociationsResour
 		if diags = m.Github.As(ctx, &gm, basetypes.ObjectAsOptions{}); diags.HasError() {
 			return nil, diags
 		}
+		if gm.AppID.IsNull() || gm.AppID.IsUnknown() {
+			diags.AddError("missing app_id",
+				"The github block now requires app_id. Set it to the GitHub App ID, or migrate to github_installation blocks.")
+			return nil, diags
+		}
+		assoc.Github = &iam.AccountAssociations_GitHub{
+			AppInstallations: map[int64]*iam.AccountAssociations_GitHubAppInstallations{
+				gm.AppID.ValueInt64(): {
+					Installations: []*iam.AccountAssociations_GitHubInstallation{{
+						InstallationId: gm.InstallationID.ValueInt64(),
+						Name:           gm.Name.ValueString(),
+					}},
+				},
+			},
+		}
+	}
 
-		assoc.Github = &iam.AccountAssociations_GitHubInstallation{
-			InstallationId: gm.InstallationID.ValueInt64(),
-			Name:           gm.Name.ValueString(),
+	if len(m.GithubInstallation) > 0 {
+		appInstalls := make(map[int64]*iam.AccountAssociations_GitHubAppInstallations, len(m.GithubInstallation))
+		for _, gh := range m.GithubInstallation {
+			appID := gh.AppID.ValueInt64()
+			if appInstalls[appID] == nil {
+				appInstalls[appID] = &iam.AccountAssociations_GitHubAppInstallations{}
+			}
+			appInstalls[appID].Installations = append(appInstalls[appID].Installations, &iam.AccountAssociations_GitHubInstallation{
+				InstallationId: gh.InstallationID.ValueInt64(),
+				Name:           gh.Name.ValueString(),
+			})
+		}
+		assoc.Github = &iam.AccountAssociations_GitHub{
+			AppInstallations: appInstalls,
 		}
 	}
 
@@ -481,14 +544,40 @@ func (r *accountAssociationsResource) Read(ctx context.Context, req resource.Rea
 	}
 
 	if assoc.Github != nil {
-		gm := githubAccountModel{
-			Host:           types.StringValue(assoc.Github.Host),
-			AppID:          types.Int64Value(assoc.Github.AppId),
-			InstallationID: types.Int64Value(assoc.Github.InstallationId),
-			Name:           types.StringValue(assoc.Github.Name),
+		sortedAppIDs := slices.Sorted(maps.Keys(assoc.Github.GetAppInstallations()))
+		if !state.Github.IsNull() {
+			// Deprecated path: flatten to the first installation for backwards compat.
+			found := false
+		outer:
+			for _, appID := range sortedAppIDs {
+				for _, inst := range assoc.Github.GetAppInstallations()[appID].GetInstallations() {
+					gm := githubAccountModel{
+						Host:           types.StringValue(""),
+						AppID:          types.Int64Value(appID),
+						InstallationID: types.Int64Value(inst.GetInstallationId()),
+						Name:           types.StringValue(inst.GetName()),
+					}
+					state.Github, diags = types.ObjectValueFrom(ctx, state.Github.AttributeTypes(ctx), gm)
+					resp.Diagnostics.Append(diags...)
+					found = true
+					break outer
+				}
+			}
+			if !found {
+				state.Github = types.ObjectNull(state.Github.AttributeTypes(ctx))
+			}
+		} else {
+			state.GithubInstallation = nil
+			for _, appID := range sortedAppIDs {
+				for _, inst := range assoc.Github.GetAppInstallations()[appID].GetInstallations() {
+					state.GithubInstallation = append(state.GithubInstallation, &githubInstallationModel{
+						AppID:          types.Int64Value(appID),
+						InstallationID: types.Int64Value(inst.GetInstallationId()),
+						Name:           types.StringValue(inst.GetName()),
+					})
+				}
+			}
 		}
-		state.Github, diags = types.ObjectValueFrom(ctx, state.Github.AttributeTypes(ctx), gm)
-		resp.Diagnostics.Append(diags...)
 	}
 
 	if resp.Diagnostics.HasError() {


### PR DESCRIPTION
### What

Bump `chainguard.dev/sdk` from `v0.1.52` to `v0.1.53` and update `chainguard_account_associations` to support the new 1:N:M GitHub App installation model. The existing `github` block is preserved (deprecated) for backwards compatibility, and a new repeatable `github_installation` block is added for multiple installations.

### Why

The bump to v0.1.53 includes a breaking proto change (https://github.com/chainguard-dev/mono/pull/36958) that shifted `AccountAssociations_GitHub` from a single flat installation to a nested `app_id → []installation` map.

https://github.com/chainguard-dev/terraform-provider-chainguard/actions/runs/24680828913/job/72177314433

### Notes

**Migration path (deprecated `github` block):**

Existing configs just need to add `app_id`:

```hcl
github {
  app_id          = 12345    # new — was previously server-populated
  installation_id = 67890
  name            = "my-org"
}
```

The `host` field is deprecated (always returns `""`). Configs missing `app_id` get a clear validation error rather than a schema crash. The `github` block was previously marked EXPERIMENTAL in the proto so the impact of requiring app_id "should" be minimal.

**New `github_installation` block (recommended):**

For multiple installations, use the new repeatable block:

```hcl
github_installation {
  app_id          = 12345
  installation_id = 67890
  name            = "org-a"
}

github_installation {
  app_id          = 12345
  installation_id = 99999
  name            = "org-b"
}
```

The two blocks are mutually exclusive (`ConflictsWith`). Both paths build the same `AppInstallations` proto map. The server requires `app_id` as a positive integer on create — there is no way to preserve the old behavior of server-side `app_id` resolution without a server change.