### PR TITLE
feat: migrate data sources to v2beta1 SDK (Groups, Roles, Repos)

### DIFF
--- a/internal/provider/data_source_group.go
+++ b/internal/provider/data_source_group.go
@@ -15,8 +15,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
+	iamv2 "chainguard.dev/sdk/proto/chainguard/platform/iam/v2beta1"
 	common "chainguard.dev/sdk/proto/platform/common/v1"
-	iam "chainguard.dev/sdk/proto/platform/iam/v1"
 	"chainguard.dev/sdk/uidp"
 	"github.com/chainguard-dev/terraform-provider-chainguard/internal/validators"
 )
@@ -93,16 +93,30 @@ func (d *groupDataSource) Read(ctx context.Context, req datasource.ReadRequest, 
 	}
 	tflog.Info(ctx, fmt.Sprintf("read group data-source request: name=%s, parent_id=%s", data.Name, data.ParentID))
 
+	if data.ID.ValueString() != "" {
+		g, err := d.prov.clientV2.IAM().GroupsService().GetGroup(ctx, &iamv2.GetGroupRequest{
+			Uid: data.ID.ValueString(),
+		})
+		if err != nil {
+			resp.Diagnostics.Append(errorToDiagnostic(err, "failed to get group"))
+			return
+		}
+		data.ID = types.StringValue(g.GetUid())
+		data.Name = types.StringValue(g.GetName())
+		data.Description = types.StringValue(g.GetDescription())
+		data.ParentID = types.StringValue(uidp.Parent(g.GetUid()))
+		resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+		return
+	}
+
 	uf := &common.UIDPFilter{}
 	if data.ParentID.ValueString() != "" && data.ParentID.ValueString() != "/" {
 		uf.ChildrenOf = data.ParentID.ValueString()
 	}
-	f := &iam.GroupFilter{
-		Id:   data.ID.ValueString(),
-		Name: data.Name.ValueString(),
+	groups, err := d.prov.clientV2.IAM().ListGroupsAll(ctx, &iamv2.ListGroupsRequest{
 		Uidp: uf,
-	}
-	groupList, err := d.prov.client.IAM().Groups().List(ctx, f)
+		Name: data.Name.ValueString(),
+	})
 	if err != nil {
 		resp.Diagnostics.Append(errorToDiagnostic(err, "failed to list groups"))
 		return
@@ -111,50 +125,46 @@ func (d *groupDataSource) Read(ctx context.Context, req datasource.ReadRequest, 
 	// Remove non-organization groups if parent_id is root sentinel
 	if data.ParentID.ValueString() == "/" {
 		tflog.Info(ctx, "filtering by root")
-		groups := make([]*iam.Group, 0, len(groupList.GetItems()))
-		for _, g := range groupList.GetItems() {
-			if uidp.InRoot(g.Id) {
-				tflog.Info(ctx, fmt.Sprintf("found an organization: %s", g.Id))
-				groups = append(groups, g)
+		orgs := make([]*iamv2.Group, 0, len(groups))
+		for _, g := range groups {
+			if uidp.InRoot(g.GetUid()) {
+				tflog.Info(ctx, fmt.Sprintf("found an organization: %s", g.GetUid()))
+				orgs = append(orgs, g)
 			}
 		}
-		groupList.Items = groups
+		groups = orgs
 	}
 
 	// When looking up by name, prefer verified groups. This avoids
 	// "too many found" errors when multiple groups share a name but
 	// only one is verified (verified names are globally unique).
-	items := groupList.GetItems()
-	if data.Name.ValueString() != "" && len(items) > 1 {
-		verified := make([]*iam.Group, 0, len(items))
-		for _, g := range items {
+	if data.Name.ValueString() != "" && len(groups) > 1 {
+		verified := make([]*iamv2.Group, 0, len(groups))
+		for _, g := range groups {
 			if g.GetVerified() {
 				verified = append(verified, g)
 			}
 		}
 		if len(verified) > 0 {
-			tflog.Info(ctx, fmt.Sprintf("narrowed %d groups to %d verified group(s)", len(items), len(verified)))
-			items = verified
+			tflog.Info(ctx, fmt.Sprintf("narrowed %d groups to %d verified group(s)", len(groups), len(verified)))
+			groups = verified
 		}
 	}
 
-	switch c := len(items); c {
+	switch c := len(groups); c {
 	case 0:
-		// Group was not found (either never existed, or was deleted).
 		resp.Diagnostics.Append(dataNotFound("group", "" /* extra */, data))
 
 	case 1:
-		g := items[0]
-		data.ID = types.StringValue(g.Id)
-		data.Name = types.StringValue(g.Name)
-		data.Description = types.StringValue(g.Description)
-		data.ParentID = types.StringValue(uidp.Parent(g.Id))
-
-		// Set state
+		g := groups[0]
+		data.ID = types.StringValue(g.GetUid())
+		data.Name = types.StringValue(g.GetName())
+		data.Description = types.StringValue(g.GetDescription())
+		data.ParentID = types.StringValue(uidp.Parent(g.GetUid()))
 		resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 
 	default:
-		tflog.Error(ctx, fmt.Sprintf("group list returned %d groups for filter %v", c, f))
+		tflog.Error(ctx, fmt.Sprintf("group list returned %d groups for %s", c, data.InputParams()))
 		resp.Diagnostics.Append(dataTooManyFound("group", "Please provide more context to narrow query (e.g. parent_id).", data))
 	}
 }

--- a/internal/provider/data_source_group_test.go
+++ b/internal/provider/data_source_group_test.go
@@ -48,7 +48,7 @@ data "chainguard_group" "bad" {
   id = "not-a-valid-uidp"
 }
 `,
-				ExpectError: regexp.MustCompile(`not found`),
+				ExpectError: regexp.MustCompile(`(not found|failed to get group)`),
 			},
 		},
 	})

--- a/internal/provider/data_source_image_repo.go
+++ b/internal/provider/data_source_image_repo.go
@@ -8,15 +8,17 @@ package provider
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
+	regv2 "chainguard.dev/sdk/proto/chainguard/platform/registry/v2beta1"
 	common "chainguard.dev/sdk/proto/platform/common/v1"
-	registry "chainguard.dev/sdk/proto/platform/registry/v1"
 	"github.com/chainguard-dev/terraform-provider-chainguard/internal/validators"
 	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
@@ -170,80 +172,116 @@ func (d *imageRepoDataSource) Read(ctx context.Context, req datasource.ReadReque
 		return
 	}
 	tflog.Info(ctx, "read imageRepo data-source request", map[string]any{"input-params": data.InputParams()})
-	filter := &registry.RepoFilter{}
-	if !data.ID.IsNull() {
-		filter.Id = data.ID.ValueString()
+
+	if !data.ID.IsNull() && data.ID.ValueString() != "" {
+		repo, err := d.prov.clientV2.Registry().ReposService().GetRepo(ctx, &regv2.GetRepoRequest{
+			Uid: data.ID.ValueString(),
+		})
+		if err != nil {
+			resp.Diagnostics.Append(errorToDiagnostic(err, "failed to get repo"))
+			return
+		}
+		repoModel, diags := repoToModel(ctx, repo)
+		resp.Diagnostics.Append(diags...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+		data.Items = append(data.Items, repoModel)
+		data.ID = types.StringValue(repo.GetUid())
+		resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+		return
 	}
+
+	listReq := &regv2.ListReposRequest{}
 	if !data.Name.IsNull() {
-		filter.Name = data.Name.ValueString()
+		name := data.Name.ValueString()
+		listReq.Name = &name
 	}
 	if !data.ParentID.IsNull() {
-		filter.Uidp = &common.UIDPFilter{
+		listReq.Uidp = &common.UIDPFilter{
 			ChildrenOf: data.ParentID.ValueString(),
 		}
 	}
-	items, err := d.prov.client.Registry().Registry().ListRepos(ctx, filter)
+	repos, err := d.prov.clientV2.Registry().ListReposAll(ctx, listReq)
 	if err != nil {
 		resp.Diagnostics.Append(errorToDiagnostic(err, "failed to list repos"))
 		return
 	}
-	for _, repo := range items.GetItems() {
-		bundles, diags := types.ListValueFrom(ctx, types.StringType, repo.GetBundles())
+	for _, repo := range repos {
+		repoModel, diags := repoToModel(ctx, repo)
 		resp.Diagnostics.Append(diags...)
-		if diags.HasError() {
+		if resp.Diagnostics.HasError() {
 			return
 		}
-
-		aliases, diags := types.ListValueFrom(ctx, types.StringType, repo.GetAliases())
-		resp.Diagnostics.Append(diags...)
-		if diags.HasError() {
-			return
-		}
-
-		activeTags, diags := types.ListValueFrom(ctx, types.StringType, repo.GetActiveTags())
-		resp.Diagnostics.Append(diags...)
-		if diags.HasError() {
-			return
-		}
-
-		var sc *syncConfig
-		if repo.SyncConfig != nil {
-			expiration := types.StringNull()
-			if repo.GetSyncConfig().GetExpiration() != nil && !repo.GetSyncConfig().GetExpiration().AsTime().IsZero() {
-				expiration = types.StringValue(repo.GetSyncConfig().GetExpiration().AsTime().Format(time.RFC3339))
-			}
-			sc = &syncConfig{
-				Source:      types.StringValue(repo.GetSyncConfig().GetSource()),
-				Expiration:  expiration,
-				UniqueTags:  types.BoolValue(repo.GetSyncConfig().GetUniqueTags()),
-				GracePeriod: types.BoolValue(repo.GetSyncConfig().GetGracePeriod()),
-				Google:      types.StringValue(repo.GetSyncConfig().GetGoogle()),
-				Amazon:      types.StringValue(repo.GetSyncConfig().GetAmazon()),
-				Azure:       types.StringValue(repo.GetSyncConfig().GetAzure()),
-				ApkoOverlay: types.StringValue(repo.GetSyncConfig().GetApkoOverlay()),
-			}
-		}
-		data.Items = append(data.Items, &imageRepoModel{
-			ID:          types.StringValue(repo.GetId()),
-			Name:        types.StringValue(repo.GetName()),
-			Bundles:     bundles,
-			Readme:      types.StringValue(repo.GetReadme()),
-			SyncConfig:  sc,
-			Tier:        types.StringValue(repo.GetCatalogTier().String()),
-			Description: types.StringValue(repo.GetDescription()),
-			Aliases:     aliases,
-			ActiveTags:  activeTags,
-		})
+		data.Items = append(data.Items, repoModel)
 	}
-	if len(items.GetItems()) == 0 {
+	if len(repos) == 0 {
 		resp.Diagnostics.Append(dataNotFound("repo", "check your input" /* extra */, data))
 		return
-	} else if len(items.GetItems()) == 1 {
-		data.ID = types.StringValue(items.GetItems()[0].GetId())
+	} else if len(repos) == 1 {
+		data.ID = types.StringValue(repos[0].GetUid())
 	} else if d.prov.testing {
-		// Set the ID on imageRepoModel for acceptance tests.
-		// https://developer.hashicorp.com/terraform/tutorials/providers-plugin-framework/providers-plugin-framework-acceptance-testing#implement-data-source-id-attribute
 		data.ID = types.StringValue("placeholder")
 	}
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func repoToModel(ctx context.Context, repo *regv2.Repo) (*imageRepoModel, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	bundles, d := types.ListValueFrom(ctx, types.StringType, repo.GetBundles())
+	diags.Append(d...)
+	if d.HasError() {
+		return nil, diags
+	}
+
+	aliases, d := types.ListValueFrom(ctx, types.StringType, repo.GetAliases())
+	diags.Append(d...)
+	if d.HasError() {
+		return nil, diags
+	}
+
+	activeTags, d := types.ListValueFrom(ctx, types.StringType, repo.GetActiveTags())
+	diags.Append(d...)
+	if d.HasError() {
+		return nil, diags
+	}
+
+	var sc *syncConfig
+	if repo.SyncConfig != nil {
+		expiration := types.StringNull()
+		if repo.GetSyncConfig().GetExpirationTime() != nil && !repo.GetSyncConfig().GetExpirationTime().AsTime().IsZero() {
+			expiration = types.StringValue(repo.GetSyncConfig().GetExpirationTime().AsTime().Format(time.RFC3339))
+		}
+		sc = &syncConfig{
+			Source:      types.StringValue(repo.GetSyncConfig().GetSource()),
+			Expiration:  expiration,
+			UniqueTags:  types.BoolValue(repo.GetSyncConfig().GetUniqueTags()),
+			GracePeriod: types.BoolValue(repo.GetSyncConfig().GetGracePeriod()),
+			Google:      types.StringValue(repo.GetSyncConfig().GetGoogle()),
+			Amazon:      types.StringValue(repo.GetSyncConfig().GetAmazon()),
+			Azure:       types.StringValue(repo.GetSyncConfig().GetAzure()),
+			ApkoOverlay: types.StringValue(repo.GetSyncConfig().GetApkoOverlay()),
+		}
+	}
+
+	return &imageRepoModel{
+		ID:          types.StringValue(repo.GetUid()),
+		Name:        types.StringValue(repo.GetName()),
+		Bundles:     bundles,
+		Readme:      types.StringValue(repo.GetReadme()),
+		SyncConfig:  sc,
+		Tier:        types.StringValue(catalogTierString(repo.GetCatalogTier())),
+		Description: types.StringValue(repo.GetDescription()),
+		Aliases:     aliases,
+		ActiveTags:  activeTags,
+	}, diags
+}
+
+// catalogTierString normalizes v2beta1 CatalogTier enum names to match
+// the v1 format used elsewhere in the provider (e.g., "APPLICATION" not
+// "CATALOG_TIER_APPLICATION").
+func catalogTierString(tier regv2.CatalogTier) string {
+	s := tier.String()
+	return strings.TrimPrefix(s, "CATALOG_TIER_")
 }

--- a/internal/provider/data_source_image_repos.go
+++ b/internal/provider/data_source_image_repos.go
@@ -9,10 +9,9 @@ import (
 	"context"
 	"crypto/sha256"
 	"fmt"
-	"time"
 
+	regv2 "chainguard.dev/sdk/proto/chainguard/platform/registry/v2beta1"
 	common "chainguard.dev/sdk/proto/platform/common/v1"
-	registry "chainguard.dev/sdk/proto/platform/registry/v1"
 	"github.com/chainguard-dev/terraform-provider-chainguard/internal/validators"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
@@ -144,73 +143,32 @@ func (d *imageReposDataSource) Read(ctx context.Context, req datasource.ReadRequ
 
 	tflog.Info(ctx, "read imageRepos data-source request", map[string]any{"input-params": data.InputParams()})
 
-	filter := &registry.RepoFilter{}
+	listReq := &regv2.ListReposRequest{}
 	if !data.Name.IsNull() {
-		filter.Name = data.Name.ValueString()
+		name := data.Name.ValueString()
+		listReq.Name = &name
 	}
 	if !data.ParentID.IsNull() {
-		filter.Uidp = &common.UIDPFilter{
+		listReq.Uidp = &common.UIDPFilter{
 			ChildrenOf: data.ParentID.ValueString(),
 		}
 	}
 
-	items, err := d.prov.client.Registry().Registry().ListRepos(ctx, filter)
+	repos, err := d.prov.clientV2.Registry().ListReposAll(ctx, listReq)
 	if err != nil {
 		resp.Diagnostics.Append(errorToDiagnostic(err, "failed to list repos"))
 		return
 	}
 
-	// Initialize items slice to ensure it's not nil even if no repos found
 	data.Items = make([]*imageRepoModel, 0)
 
-	for _, repo := range items.GetItems() {
-		bundles, diags := types.ListValueFrom(ctx, types.StringType, repo.GetBundles())
+	for _, repo := range repos {
+		repoModel, diags := repoToModel(ctx, repo)
 		resp.Diagnostics.Append(diags...)
-		if diags.HasError() {
+		if resp.Diagnostics.HasError() {
 			return
 		}
-
-		aliases, diags := types.ListValueFrom(ctx, types.StringType, repo.GetAliases())
-		resp.Diagnostics.Append(diags...)
-		if diags.HasError() {
-			return
-		}
-
-		activeTags, diags := types.ListValueFrom(ctx, types.StringType, repo.GetActiveTags())
-		resp.Diagnostics.Append(diags...)
-		if diags.HasError() {
-			return
-		}
-
-		var sc *syncConfig
-		if repo.SyncConfig != nil {
-			expiration := types.StringNull()
-			if repo.GetSyncConfig().GetExpiration() != nil && !repo.GetSyncConfig().GetExpiration().AsTime().IsZero() {
-				expiration = types.StringValue(repo.GetSyncConfig().GetExpiration().AsTime().Format(time.RFC3339))
-			}
-			sc = &syncConfig{
-				Source:      types.StringValue(repo.GetSyncConfig().GetSource()),
-				Expiration:  expiration,
-				UniqueTags:  types.BoolValue(repo.GetSyncConfig().GetUniqueTags()),
-				GracePeriod: types.BoolValue(repo.GetSyncConfig().GetGracePeriod()),
-				Google:      types.StringValue(repo.GetSyncConfig().GetGoogle()),
-				Amazon:      types.StringValue(repo.GetSyncConfig().GetAmazon()),
-				Azure:       types.StringValue(repo.GetSyncConfig().GetAzure()),
-				ApkoOverlay: types.StringValue(repo.GetSyncConfig().GetApkoOverlay()),
-			}
-		}
-
-		data.Items = append(data.Items, &imageRepoModel{
-			ID:          types.StringValue(repo.GetId()),
-			Name:        types.StringValue(repo.GetName()),
-			Bundles:     bundles,
-			Readme:      types.StringValue(repo.GetReadme()),
-			SyncConfig:  sc,
-			Tier:        types.StringValue(repo.GetCatalogTier().String()),
-			Description: types.StringValue(repo.GetDescription()),
-			Aliases:     aliases,
-			ActiveTags:  activeTags,
-		})
+		data.Items = append(data.Items, repoModel)
 	}
 
 	// Generate a unique ID based on the filter parameters

--- a/internal/provider/data_source_role.go
+++ b/internal/provider/data_source_role.go
@@ -15,7 +15,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
-	iam "chainguard.dev/sdk/proto/platform/iam/v1"
+	"chainguard.dev/sdk/proto/capabilities"
+	iamv2 "chainguard.dev/sdk/proto/chainguard/platform/iam/v2beta1"
+	common "chainguard.dev/sdk/proto/platform/common/v1"
 	"github.com/chainguard-dev/terraform-provider-chainguard/internal/validators"
 )
 
@@ -121,36 +123,58 @@ func (d *roleDataSource) Read(ctx context.Context, req datasource.ReadRequest, r
 	}
 	tflog.Info(ctx, "read role data-source request", map[string]any{"input-params": data.InputParams()})
 
-	all, err := d.prov.client.IAM().Roles().List(ctx, &iam.RoleFilter{
-		Id:     data.ID.ValueString(),
-		Name:   data.Name.ValueString(),
-		Parent: data.Parent.ValueString(),
+	if data.ID.ValueString() != "" {
+		role, err := d.prov.clientV2.IAM().RolesService().GetRole(ctx, &iamv2.GetRoleRequest{
+			Uid: data.ID.ValueString(),
+		})
+		if err != nil {
+			resp.Diagnostics.Append(errorToDiagnostic(err, "failed to get role"))
+			return
+		}
+		caps, diags := types.ListValueFrom(ctx, types.StringType, capabilityStrings(role.GetCapabilities()))
+		resp.Diagnostics.Append(diags...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+		data.Items = append(data.Items, &roleModel{
+			ID:           types.StringValue(role.GetUid()),
+			Name:         types.StringValue(role.GetName()),
+			Description:  types.StringValue(role.GetDescription()),
+			Capabilities: caps,
+		})
+		resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+		return
+	}
+
+	uf := &common.UIDPFilter{}
+	if v := data.Parent.ValueString(); v != "" && v != "/" {
+		uf.ChildrenOf = v
+	}
+	roles, err := d.prov.clientV2.IAM().ListRolesAll(ctx, &iamv2.ListRolesRequest{
+		Uidp: uf,
+		Name: data.Name.ValueString(),
 	})
 	if err != nil {
 		resp.Diagnostics.Append(errorToDiagnostic(err, "failed to list roles"))
 		return
 	}
 
-	for _, role := range all.GetItems() {
-		caps, diags := types.ListValueFrom(ctx, types.StringType, role.Capabilities)
-		// Collect returned warnings/errors.
+	for _, role := range roles {
+		caps, diags := types.ListValueFrom(ctx, types.StringType, capabilityStrings(role.GetCapabilities()))
 		resp.Diagnostics.Append(diags...)
 		if diags.HasError() {
-			// Don't return a role if errors encountered converting the capabilities.
-			// This /shouldn't/ happen since the caps are coming from the API.
-			tflog.Error(ctx, "failed to convert capabilities to basetypes.ListValue", map[string]any{"caps": role.Capabilities})
+			tflog.Error(ctx, "failed to convert capabilities to basetypes.ListValue", map[string]any{"caps": role.GetCapabilities()})
 			continue
 		}
 
 		data.Items = append(data.Items, &roleModel{
-			ID:           types.StringValue(role.Id),
-			Name:         types.StringValue(role.Name),
-			Description:  types.StringValue(role.Description),
+			ID:           types.StringValue(role.GetUid()),
+			Name:         types.StringValue(role.GetName()),
+			Description:  types.StringValue(role.GetDescription()),
 			Capabilities: caps,
 		})
 	}
-	// Role wasn't found, or was deleted outside Terraform
-	if len(all.GetItems()) == 0 {
+	if len(roles) == 0 {
 		resp.Diagnostics.Append(dataNotFound("role", "" /* extra */, data))
 		return
 	} else if d.prov.testing {
@@ -161,4 +185,12 @@ func (d *roleDataSource) Read(ctx context.Context, req datasource.ReadRequest, r
 
 	// Set state
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func capabilityStrings(caps []capabilities.Capability) []string {
+	strs := make([]string, 0, len(caps))
+	for _, c := range caps {
+		strs = append(strs, c.String())
+	}
+	return strs
 }

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -29,6 +29,7 @@ import (
 	"google.golang.org/grpc/status"
 
 	"chainguard.dev/sdk/auth"
+	clientsv2 "chainguard.dev/sdk/proto/chainguard/platform/clients/v2beta1"
 	"chainguard.dev/sdk/proto/platform"
 	"github.com/chainguard-dev/terraform-provider-chainguard/internal/protoutil"
 	"github.com/chainguard-dev/terraform-provider-chainguard/internal/token"
@@ -224,6 +225,7 @@ only consider the filtered versions.`,
 
 type providerData struct {
 	client   platform.Clients
+	clientV2 clientsv2.Clients
 	clientMu sync.Mutex
 
 	consoleAPI          string
@@ -397,7 +399,14 @@ func (pd *providerData) setupClient(ctx context.Context) error {
 		return fmt.Errorf("failed to create API clients: %s", err.Error())
 	}
 
+	cred := auth.NewFromToken(ctx, fmt.Sprintf("Bearer %s", string(cgToken)), false)
+	v2, err := clientsv2.NewClients(ctx, pd.consoleAPI, UserAgent, cred)
+	if err != nil {
+		return fmt.Errorf("failed to create v2beta1 API clients: %s", err.Error())
+	}
+
 	pd.client = clients
+	pd.clientV2 = v2
 	return nil
 }
 


### PR DESCRIPTION
### What

Migrate 4 data sources from v1 to v2beta1 SDK: `data_source_group`, `data_source_role`, `data_source_image_repo`, `data_source_image_repos`. Adds `clientV2` (v2beta1) alongside the existing v1 client in the provider.

### Why

Dogfooding the v2beta1 public SDK that external customers will use. Data sources are read-only (List/Get), making them the lowest-risk migration target. Part of CUS-320

### Notes

- Groups, Roles, and Repos data sources now use `GetGroup` / `GetRole` / `GetRepo` for direct ID lookups (v1 had no Get methods)
- Repos data sources use the `ListReposAll` pagination helper from the SDK
- `repoToModel` helper extracted to share conversion logic between `data_source_image_repo` and `data_source_image_repos`
- CatalogTier and capabilities output is normalized to match v1 format, so existing Terraform configs see no drift
- v2 returns `InvalidArgument` for malformed UIDs (v1 returned "not found") — updated the invalid ID test to match  
- Roles parent="/" (platform-level roles): v1 treated "/" as a special sentinel in `RoleFilter.Parent`; v2beta1 uses `UIDPFilter` which doesn't recognize it. Fixed by skipping the filter for "/", matching the groups data source pattern