### PR TITLE
fix(release): use hkps:// for GPG keyserver to fix harden-runner block

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -126,7 +126,7 @@ jobs:
         env:
           GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}
         run: |
-          gpg --keyserver keys.openpgp.org --send-keys "$GPG_FINGERPRINT"
+          gpg --keyserver hkps://keys.openpgp.org --send-keys "$GPG_FINGERPRINT"
 
       - uses: goreleaser/goreleaser-action@e24998b8b67b290c2fa8b7c14fcfa7de2c5c9b8c # v7.1.0
         if: steps.check.outputs.need_release == 'yes'


### PR DESCRIPTION
Without an explicit scheme, GPG defaults to hkp:// (port 80), which is blocked by the harden-runner egress policy. Using hkps:// forces TLS on port 443, which is already in the allowlist.