### PR TITLE
Bump apko to v1.2.9

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/chainguard-dev/terraform-provider-chainguard
 go 1.25.8
 
 require (
-	chainguard.dev/apko v1.2.8
+	chainguard.dev/apko v1.2.9
 	chainguard.dev/sdk v0.1.54
 	github.com/chainguard-dev/clog v1.8.0
 	github.com/coreos/go-oidc/v3 v3.18.0

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-chainguard.dev/apko v1.2.8 h1:K6iGkbHibac6SgahBtfOQTaepzPRm0WP7VkMbu46WCM=
-chainguard.dev/apko v1.2.8/go.mod h1:JzjuFno6z5Up2BctVE/sZevJoGjBAu3OtuYwwJd6f58=
+chainguard.dev/apko v1.2.9 h1:VwkEy+kRaHzqw+FlWnmZ3ikzr0BMu+U5hCrm9c9BZPM=
+chainguard.dev/apko v1.2.9/go.mod h1:QqLySr8qZy4QIY5vOnJjnsdGKa45QrerxmBpNFJbEuE=
 chainguard.dev/go-grpc-kit v0.17.17 h1:Jwhc0zyUwQbC2hNcsi+YMeUX/JUnM+dXVCkTw6wtPzs=
 chainguard.dev/go-grpc-kit v0.17.17/go.mod h1:qn0meP6RtrbLicE1bgBZnnVU9dvX95eLs0x0T6kZ+b4=
 chainguard.dev/go-oidctest v0.4.0 h1:B9YTfoa1WtsrEg0wnFeSP7i9tth0LO+GICm2j8HOgWI=


### PR DESCRIPTION
## Summary

- Bumps `chainguard.dev/apko` from v1.2.7 to v1.2.9 (security fix release)

## Test plan

- [ ] CI passes
- [ ] Trigger `workflow_dispatch` on release.yml after merge