### PR TITLE
Address zizmor findings across workflows

### DIFF
--- a/.github/workflows/actionlint.yaml
+++ b/.github/workflows/actionlint.yaml
@@ -17,6 +17,10 @@ on:
 
 permissions: {}
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   action-lint:
     permissions:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,6 +10,10 @@ on:
 
 permissions: {}
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   build:
     name: Build

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,6 +5,10 @@ on:
 
 permissions: {}
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   golangci:
     name: lint

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,10 @@ on:
 
 permissions: {}
 
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
 jobs:
   release:
     name: Release

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,6 +16,10 @@ on:
 
 permissions: {}
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.head.ref || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request_target' }}
+
 jobs:
   # Run acceptance tests in a matrix with Terraform CLI versions
   test:
@@ -41,7 +45,7 @@ jobs:
 
     permissions:
       contents: read
-      id-token: write
+      id-token: write # OIDC token for chainctl federated auth against the Chainguard API.
 
     strategy:
       fail-fast: false
@@ -84,7 +88,10 @@ jobs:
         with:
           go-version-file: "go.mod"
           check-latest: true
-          cache: true
+          # Disable Go build cache: with pull_request_target, an attacker-
+          # controlled PR could otherwise poison the cache used by trusted
+          # base-branch runs.
+          cache: false
 
       - uses: chainguard-dev/setup-chainctl@2cddd35a2f120d9973e58094dc6878c93cf58c28 # v0.5.1
         with:
@@ -101,11 +108,13 @@ jobs:
         run: go build -o terraform-provider-chainguard
 
       - name: Setup Terraform dev overrides
+        env:
+          WORKSPACE: ${{ github.workspace }}
         run: |
           cat > ~/.terraformrc << EOF
           provider_installation {
             dev_overrides {
-              "chainguard-dev/chainguard" = "${{ github.workspace }}"
+              "chainguard-dev/chainguard" = "${WORKSPACE}"
             }
             direct {}
           }

--- a/.github/workflows/zizmor.yaml
+++ b/.github/workflows/zizmor.yaml
@@ -17,6 +17,10 @@ on:
 
 permissions: {}
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   zizmor:
     name: Zizmor


### PR DESCRIPTION
Adds per-workflow concurrency groups so PR iterations cancel stale runs while pushes to main and releases serialize (releases queue rather than cancel, since cancelling mid-goreleaser leaves half-published artifacts). Disables Go module cache in the acceptance-tests workflow because it runs under pull_request_target, where a fork PR could otherwise poison the cache used by trusted base-branch runs. Documents the id-token: write permission and moves github.workspace through an env var to silence the template-injection audit. The remaining pull_request_target finding is intentionally left as-is per the workflow's existing inline justification.
