### PR TITLE
Bump Go to 1.26 and golangci-lint to v2.12

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -50,4 +50,4 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0
         with:
-          version: v2.8
+          version: v2.12

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/chainguard-dev/terraform-provider-chainguard
 
-go 1.25.8
+go 1.26.3
 
 require (
 	chainguard.dev/apko v1.2.10

--- a/internal/provider/data_source_schema_test.go
+++ b/internal/provider/data_source_schema_test.go
@@ -188,8 +188,7 @@ func validateModelAgainstSchema(model any, schemaAttrs map[string]schema.Attribu
 	}
 
 	var missingInSchema []string
-	for i := 0; i < modelType.NumField(); i++ {
-		field := modelType.Field(i)
+	for field := range modelType.Fields() {
 		tfsdkTag := field.Tag.Get("tfsdk")
 		if tfsdkTag == "" || tfsdkTag == "-" {
 			continue

--- a/internal/provider/resource_account_associations_test.go
+++ b/internal/provider/resource_account_associations_test.go
@@ -288,7 +288,7 @@ func mapToTF(m map[string]string) string {
 		if !first {
 			clientIdsBuilder.WriteString(`, `)
 		}
-		clientIdsBuilder.WriteString(fmt.Sprintf(`%s = "%s"`, component, clientid))
+		fmt.Fprintf(&clientIdsBuilder, `%s = "%s"`, component, clientid)
 	}
 	clientIdsBuilder.WriteString(`}`)
 	return clientIdsBuilder.String()


### PR DESCRIPTION
Picks up new modernize and staticcheck rules from golangci-lint v2.12 — adopts the Go 1.26 reflect.Type.Fields() iterator in data_source_schema_test.go and switches a strings.Builder WriteString(fmt.Sprintf(...)) call to fmt.Fprintf.
