### PR TITLE
fix(token): re-mint ambient OIDC token on refresh

### DIFF
--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -25,7 +25,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
-	"github.com/sigstore/cosign/v2/pkg/providers"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -309,21 +308,12 @@ func (p *Provider) Configure(ctx context.Context, req provider.ConfigureRequest,
 		// when providing an explicit OIDC token.
 		cfg.UseRefreshTokens = protoutil.DefaultBool(lo.EnableRefreshTokens, cfg.IdentityID == "" && cfg.IdentityToken == "")
 
-		// Look for an OIDC token in the following places (in order of precedence)
-		// 1. TF_CHAINGUARD_IDENTITY_TOKEN env var
-		// 2. Ambient GitHub credentials
-		// 3. login_options.identity_token, which is allowed to be empty
-		switch {
-		case os.Getenv("TF_CHAINGUARD_IDENTITY_TOKEN") != "":
-			cfg.IdentityToken = os.Getenv("TF_CHAINGUARD_IDENTITY_TOKEN")
-		case providers.Enabled(ctx):
-			var err error
-			cfg.IdentityToken, err = providers.Provide(ctx, cfg.Issuer)
-			if err != nil {
-				tflog.Error(ctx, fmt.Sprintf("failed to get identity token from ambient credentials: %s", err.Error()))
-			}
-		default:
-			cfg.IdentityToken = lo.IdentityToken.ValueString()
+		// Resolve the OIDC token by source precedence: TF_CHAINGUARD_IDENTITY_TOKEN
+		// env > ambient credentials > login_options.identity_token (allowed empty).
+		var err error
+		cfg.IdentityToken, err = token.ResolveIdentityToken(ctx, cfg.Issuer, lo.IdentityToken.ValueString())
+		if err != nil {
+			tflog.Error(ctx, fmt.Sprintf("failed to get identity token from ambient credentials: %s", err.Error()))
 		}
 	}
 

--- a/internal/token/token.go
+++ b/internal/token/token.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"github.com/sigstore/cosign/v2/pkg/providers"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
@@ -106,7 +107,7 @@ func refreshChainguardToken(ctx context.Context, cfg LoginConfig, forceRefresh b
 	}
 
 	if cfg.IdentityToken != "" {
-		accessToken, err = exchangeToken(ctx, cfg.IdentityToken, cfg)
+		accessToken, err = exchangeToken(ctx, identityTokenForExchange(ctx, cfg), cfg)
 	} else {
 		accessToken, refreshToken, err = getChainguardToken(ctx, cfg)
 	}
@@ -169,6 +170,33 @@ func exchangeRefreshToken(ctx context.Context, cfg LoginConfig) (cgToken string,
 
 	e := sts.New(cfg.Issuer, cfg.Audience, sts.WithUserAgent(cfg.UserAgent))
 	return e.Refresh(ctx, string(refreshTokenBytes))
+}
+
+// ResolveIdentityToken applies the OIDC identity token source precedence:
+// TF_CHAINGUARD_IDENTITY_TOKEN env > ambient credentials > fallback. The ambient
+// branch mints a fresh token on every call, so reusing this at refresh time
+// re-mints rather than reusing a possibly-expired token. It is the single source
+// of precedence shared by provider Configure and refresh.
+func ResolveIdentityToken(ctx context.Context, issuer, fallback string) (string, error) {
+	switch {
+	case os.Getenv("TF_CHAINGUARD_IDENTITY_TOKEN") != "":
+		return os.Getenv("TF_CHAINGUARD_IDENTITY_TOKEN"), nil
+	case providers.Enabled(ctx):
+		return providers.Provide(ctx, issuer)
+	default:
+		return fallback, nil
+	}
+}
+
+// identityTokenForExchange resolves the OIDC token to exchange on refresh, falling
+// back to the configured token (the captured one) if re-minting fails.
+func identityTokenForExchange(ctx context.Context, cfg LoginConfig) string {
+	tok, err := ResolveIdentityToken(ctx, cfg.Issuer, cfg.IdentityToken)
+	if err != nil {
+		tflog.Warn(ctx, fmt.Sprintf("failed to re-mint ambient identity token, reusing configured token: %v", err))
+		return cfg.IdentityToken
+	}
+	return tok
 }
 
 // exchangeToken gets a Chainguard token by exchanging the given OIDC token or path to a token.

--- a/internal/token/token_test.go
+++ b/internal/token/token_test.go
@@ -1,0 +1,97 @@
+/*
+Copyright 2026 Chainguard, Inc.
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package token
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/sigstore/cosign/v2/pkg/providers"
+)
+
+// fakeProvider is a controllable ambient OIDC provider for tests.
+type fakeProvider struct {
+	enabled bool
+	token   string
+	err     error
+}
+
+func (f *fakeProvider) Enabled(context.Context) bool { return f.enabled }
+
+func (f *fakeProvider) Provide(context.Context, string) (string, error) {
+	return f.token, f.err
+}
+
+var testProvider = &fakeProvider{}
+
+func init() {
+	providers.Register("terraform-provider-chainguard-test", testProvider)
+}
+
+// TestIdentityTokenForExchange guards the regression: on refresh, an ambient
+// token must be re-minted, not reused from the (possibly expired) one captured
+// at provider configuration time.
+func TestIdentityTokenForExchange(t *testing.T) {
+	const stale = "stale-captured-token"
+
+	// The real github-actions provider keys off these; clear them so only the
+	// fake provider decides whether ambient credentials are enabled.
+	t.Setenv("ACTIONS_ID_TOKEN_REQUEST_TOKEN", "")
+	t.Setenv("ACTIONS_ID_TOKEN_REQUEST_URL", "")
+
+	tests := map[string]struct {
+		envToken      string // TF_CHAINGUARD_IDENTITY_TOKEN
+		enabled       bool
+		minted        string
+		mintErr       error
+		identityToken string
+		want          string
+	}{
+		"explicit env token wins, not re-minted": {
+			envToken:      "explicit-env-token",
+			enabled:       true,
+			minted:        "fresh-ambient-token",
+			identityToken: "explicit-env-token",
+			want:          "explicit-env-token",
+		},
+		"ambient re-mints a fresh token": {
+			enabled:       true,
+			minted:        "fresh-ambient-token",
+			identityToken: stale,
+			want:          "fresh-ambient-token", // pre-fix returned stale -> expired-token failure
+		},
+		"ambient mint failure falls back to configured token": {
+			enabled:       true,
+			mintErr:       errors.New("oidc endpoint unavailable"),
+			identityToken: stale,
+			want:          stale,
+		},
+		"non-ambient returns configured literal/path token unchanged": {
+			enabled:       false,
+			minted:        "should-not-be-used",
+			identityToken: "literal-or-path-token",
+			want:          "literal-or-path-token",
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Setenv("TF_CHAINGUARD_IDENTITY_TOKEN", tc.envToken)
+			testProvider.enabled = tc.enabled
+			testProvider.token = tc.minted
+			testProvider.err = tc.mintErr
+
+			cfg := LoginConfig{
+				IdentityToken: tc.identityToken,
+				Issuer:        "https://issuer.example.test",
+			}
+			if got := identityTokenForExchange(context.Background(), cfg); got != tc.want {
+				t.Errorf("got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Linear: [CON-1851](https://linear.app/chainguard/issue/CON-1851)

## Problem

In an ambient-credentials environment (e.g. GitHub Actions), the provider
resolves an OIDC identity token **once**, during `Configure`, and stores it as a
fixed string in `LoginConfig.IdentityToken`. When the Chainguard access token
later needs refreshing during a long-running `apply`, the refresh path
re-exchanges that **same stored OIDC token** — it is never re-minted, even
though the ambient source remains available to issue a fresh one. If the stored
OIDC token has expired by the time the refresh runs, the exchange is attempted
with an expired token.

## Root cause

- `internal/provider/provider.go` (`Configure`) resolves the OIDC token with the
  precedence `TF_CHAINGUARD_IDENTITY_TOKEN` env > ambient (`providers.Provide`) >
  `login_options.identity_token`, and stores the result in `cfg.IdentityToken`
  a single time.
- `internal/token/token.go` (`Get` → `refreshChainguardToken`) triggers a refresh
  when the access token's remaining life `<= 0` (or on forced refresh). With
  `cfg.IdentityToken != ""`, it calls `exchangeToken(ctx, cfg.IdentityToken, cfg)`
  using the stored token unchanged.
- The ambient `github-actions` provider's `Provide` performs a fresh request to
  the Actions OIDC endpoint on every call (no caching), so re-minting is possible
  whenever ambient credentials are enabled.

Net effect: the token captured at configuration time is reused on every refresh
rather than re-minted from the still-available ambient source.

## Observed failure

Seen with the `chainguard-dev/chainguard` provider **v0.2.11** in a GitHub Actions
job whose `terraform apply` ran longer than the ambient OIDC token's lifetime.
`TF_CHAINGUARD_IDENTITY_TOKEN` was unset and the job had `id-token: write`, so the
provider resolved its identity token from ambient credentials (`providers.Provide`)
at `Configure` time. About 56 minutes later, a `data.chainguard_image_repo` read
triggered a token refresh, which re-exchanged the captured (now-expired) OIDC
token:

```
data.chainguard_image_repo.repo: unable to setup client
failed to retrieve token. Either no token was found for audience
"https://console-api.chainops.dev" or there was an error reading it.
... failed to get Chainguard token: exchanging token with "https://issuer.chainops.dev":
  rpc error: code = PermissionDenied desc = verify token:
  rpc error: code = PermissionDenied desc = verifying token:
  oidc: token is expired (Token Expiry: 2026-06-18 17:42:59 +0000 UTC)
```

The token's expiry (`17:42:59`) was ~56 minutes before the time of the failure
(`18:39:12`), confirming the captured token was reused past its lifetime instead
of being re-minted from the still-configured ambient source.

## Solution

Extract the source-precedence logic into a single helper,
`token.ResolveIdentityToken(ctx, issuer, fallback)`
(`TF_CHAINGUARD_IDENTITY_TOKEN` env > ambient `providers.Provide` > fallback), and
use it from **both** call sites:

- `Configure` calls it with the `login_options.identity_token` literal as the
  fallback (behavior unchanged).
- The refresh path calls it with the already-configured token as the fallback.
  Because the ambient branch mints a fresh token on every call, refresh now
  re-mints instead of reusing the captured token. Explicit env/literal/path
  tokens resolve unchanged, and if re-minting fails the refresh falls back to the
  configured token (same behavior as before on that error path).

This keeps the precedence in one place, so `Configure` and refresh cannot drift.
The change is confined to `internal/token` and `Configure`; there is no provider
schema or `LoginConfig` change, and the browser-login and refresh-token paths are
untouched.


## Testing

- `TestIdentityTokenForExchange` covers all branches: explicit-env precedence,
  ambient re-mint, mint-failure fallback, and non-ambient passthrough.
- The ambient re-mint case was confirmed to fail against the previous
  reuse-the-stored-token behavior (mutation check), verifying it guards the
  regression.
- `go build ./...`, `go vet ./...`, and `go test ./internal/token/` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)