### PR TITLE
Remove client-side bundle allowlist validation

### DIFF
--- a/docs/data-sources/image_repo.md
+++ b/docs/data-sources/image_repo.md
@@ -40,7 +40,7 @@ Optional:
 
 - `active_tags` (List of String) List of active tags for this repo.
 - `aliases` (List of String) Known aliases for a given image.
-- `bundles` (List of String) List of bundles associated with this repo (a-z freeform keywords for sales purposes).
+- `bundles` (List of String) List of bundles associated with this repo. Allowed values are enforced by the Chainguard API.
 - `readme` (String) The README for this repo.
 - `sync_config` (Object) (see [below for nested schema](#nestedatt--items--sync_config))
 - `tier` (String) Image tier associated with this repo.

--- a/docs/resources/image_repo.md
+++ b/docs/resources/image_repo.md
@@ -32,7 +32,7 @@ resource "chainguard_image_repo" "example" {
 
 - `active_tags` (List of String) List of active tags for this repo.
 - `aliases` (List of String) Known aliases for a given image.
-- `bundles` (List of String) List of bundles associated with this repo (valid ones: `application|base|byol|ai|ai-gpu|featured|fips`).
+- `bundles` (List of String) List of bundles associated with this repo. Allowed values are enforced by the Chainguard API.
 - `description` (String) The short description of this repo.
 - `readme` (String) The README for this repo.
 - `sync_config` (Block, Optional) Configuration for catalog syncing. (see [below for nested schema](#nestedblock--sync_config))

--- a/docs/resources/image_tag.md
+++ b/docs/resources/image_tag.md
@@ -30,7 +30,7 @@ resource "chainguard_image_tag" "example" {
 
 ### Optional
 
-- `bundles` (List of String) List of bundles associated with this repo (valid ones: `application|base|byol|ai|ai-gpu|featured|fips`).
+- `bundles` (List of String) List of bundles associated with this repo. Allowed values are enforced by the Chainguard API.
 - `deprecated` (Boolean) Whether the tag is deprecated.
 
 ### Read-Only

--- a/internal/provider/data_source_image_repo.go
+++ b/internal/provider/data_source_image_repo.go
@@ -103,12 +103,9 @@ func (d *imageRepoDataSource) Schema(_ context.Context, _ datasource.SchemaReque
 							Computed:    true,
 						},
 						"bundles": schema.ListAttribute{
-							Description: "List of bundles associated with this repo (a-z freeform keywords for sales purposes).",
+							Description: "List of bundles associated with this repo. Allowed values are enforced by the Chainguard API.",
 							Optional:    true,
 							ElementType: types.StringType,
-							Validators: []validator.List{
-								listvalidator.ValueStringsAre(validators.ValidateStringFuncs(validBundlesValue)),
-							},
 						},
 						"readme": schema.StringAttribute{
 							Description: "The README for this repo.",

--- a/internal/provider/resource_image_repo.go
+++ b/internal/provider/resource_image_repo.go
@@ -106,12 +106,9 @@ func (r *imageRepoResource) Schema(_ context.Context, _ resource.SchemaRequest, 
 				},
 			},
 			"bundles": schema.ListAttribute{
-				Description: "List of bundles associated with this repo (valid ones: `application|base|byol|ai|ai-gpu|featured|fips`).",
+				Description: "List of bundles associated with this repo. Allowed values are enforced by the Chainguard API.",
 				Optional:    true,
 				ElementType: types.StringType,
-				Validators: []validator.List{
-					listvalidator.ValueStringsAre(validators.ValidateStringFuncs(validBundlesValue)),
-				},
 			},
 			"readme": schema.StringAttribute{
 				Description: "The README for this repo.",
@@ -207,14 +204,6 @@ func (r *imageRepoResource) Schema(_ context.Context, _ resource.SchemaRequest, 
 			},
 		},
 	}
-}
-
-// validBundlesValue implements validators.ValidateStringFunc.
-func validBundlesValue(s string) error {
-	if err := validation.ValidateBundles([]string{s}); err != nil {
-		return fmt.Errorf("bundle item %q is invalid: %w", s, err)
-	}
-	return nil
 }
 
 // validAliasesValue implements validators.ValidateStringFunc.

--- a/internal/provider/resource_image_tag.go
+++ b/internal/provider/resource_image_tag.go
@@ -10,7 +10,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -85,12 +84,9 @@ func (r *imageTagResource) Schema(_ context.Context, _ resource.SchemaRequest, r
 				},
 			},
 			"bundles": schema.ListAttribute{
-				Description: "List of bundles associated with this repo (valid ones: `application|base|byol|ai|ai-gpu|featured|fips`).",
+				Description: "List of bundles associated with this repo. Allowed values are enforced by the Chainguard API.",
 				Optional:    true,
 				ElementType: types.StringType,
-				Validators: []validator.List{
-					listvalidator.ValueStringsAre(validators.ValidateStringFuncs(validBundlesValue)),
-				},
 			},
 			"digest": schema.StringAttribute{
 				Description: "The digest of the manifest with this tag.",


### PR DESCRIPTION
## Summary
- Bundle values are validated server-side by the Chainguard API (`public/sdk/validation.ValidateBundles` in mono). Duplicating the allowlist here coupled TF provider releases to allowlist edits with no correctness benefit — invalid values would still be rejected by the API, just slightly later.
- Drops `Validators` from the `bundles` attribute on `chainguard_image_repo` (resource + data source) and `chainguard_image_tag`, and deletes the now-unused `validBundlesValue` helper.
- Updates the attribute descriptions, which had already drifted (missing `commercial`).

## Trade-off
Invalid bundle values now surface at apply time as an API error rather than at plan time as a validation message. In exchange, future additions to the bundle allowlist (e.g. ``emeritoss``) take effect as soon as the API change rolls out — no provider release required.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test -short ./internal/provider/...`
- [ ] CI acceptance tests