### PR TITLE
Source image_repo README from the v1 registry API

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.26.4
 
 require (
 	chainguard.dev/apko v1.2.18
-	chainguard.dev/sdk v0.1.76
+	chainguard.dev/sdk v0.1.89
 	github.com/chainguard-dev/clog v1.8.0
 	github.com/coreos/go-oidc/v3 v3.19.0
 	github.com/google/go-cmp v0.7.0

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,8 @@ chainguard.dev/go-grpc-kit v0.17.17 h1:Jwhc0zyUwQbC2hNcsi+YMeUX/JUnM+dXVCkTw6wtP
 chainguard.dev/go-grpc-kit v0.17.17/go.mod h1:qn0meP6RtrbLicE1bgBZnnVU9dvX95eLs0x0T6kZ+b4=
 chainguard.dev/go-oidctest v0.4.0 h1:B9YTfoa1WtsrEg0wnFeSP7i9tth0LO+GICm2j8HOgWI=
 chainguard.dev/go-oidctest v0.4.0/go.mod h1:IIic4S3je1I7Acy3bqPtaSPefGEsQDzUp7NJF35MPV4=
-chainguard.dev/sdk v0.1.76 h1:ijjE6xC8MSt76Gv44r571E8E8rwoIyUlIRj2N6FZGH0=
-chainguard.dev/sdk v0.1.76/go.mod h1:t8m9wn52ylTmEaOCQWUkfxvXOIQe5xD3UsvYn1CP7Bo=
+chainguard.dev/sdk v0.1.89 h1:y38vNGDPH186NMqeav0QWCROSUCt9jKlJOqeyJXP8EM=
+chainguard.dev/sdk v0.1.89/go.mod h1:VQ7UkdhbYpwvzapYJcHixIGE7okay8HNwKPmI1Gk8ok=
 cloud.google.com/go/auth v0.20.0 h1:kXTssoVb4azsVDoUiF8KvxAqrsQcQtB53DcSgta74CA=
 cloud.google.com/go/auth v0.20.0/go.mod h1:942/yi/itH1SsmpyrbnTMDgGfdy2BUqIKyd0cyYLc5Q=
 cloud.google.com/go/auth/oauth2adapt v0.2.8 h1:keo8NaayQZ6wimpNSmW5OPc283g65QNIiLpZnkHRbnc=
@@ -314,8 +314,8 @@ go.opentelemetry.io/auto/sdk v1.2.1 h1:jXsnJ4Lmnqd11kwkBV2LgLoFMZKizbCi5fNZ/ipaZ
 go.opentelemetry.io/auto/sdk v1.2.1/go.mod h1:KRTj+aOaElaLi+wW1kO/DZRXwkF4C5xPbEe3ZiIhN7Y=
 go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.67.0 h1:yI1/OhfEPy7J9eoa6Sj051C7n5dvpj0QX8g4sRchg04=
 go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.67.0/go.mod h1:NoUCKYWK+3ecatC4HjkRktREheMeEtrXoQxrqYFeHSc=
-go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.67.0 h1:OyrsyzuttWTSur2qN/Lm0m2a8yqyIjUVBZcxFPuXq2o=
-go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.67.0/go.mod h1:C2NGBr+kAB4bk3xtMXfZ94gqFDtg/GkI7e9zqGh5Beg=
+go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.69.0 h1:8tvICD4vSTOOsNrsI4Ljf6C+6UKvpTEH5XY3JMoyPoo=
+go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.69.0/go.mod h1:z9+yiacE0IHRqM4qFfkbt/JYlmYXgss8GY/jXoNuPJI=
 go.opentelemetry.io/otel v1.44.0 h1:JjwHmHpA4iZ3wBxluu2fbbE7j4kqlE8jXyAyPXH7HqU=
 go.opentelemetry.io/otel v1.44.0/go.mod h1:BMgjTHL9WPRlRjL2oZCBTL4whCGtXch2H4BhOPIAyYc=
 go.opentelemetry.io/otel/metric v1.44.0 h1:1w0gILTcHdr3YI+ixLyjemwrVnsMURbTZFrSYCdDdmc=

--- a/internal/provider/data_source_image_repo.go
+++ b/internal/provider/data_source_image_repo.go
@@ -13,6 +13,7 @@ import (
 
 	regv2 "chainguard.dev/sdk/proto/chainguard/platform/registry/v2beta1"
 	common "chainguard.dev/sdk/proto/platform/common/v1"
+	registry "chainguard.dev/sdk/proto/platform/registry/v1"
 	"github.com/chainguard-dev/terraform-provider-chainguard/internal/validators"
 	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
@@ -178,7 +179,12 @@ func (d *imageRepoDataSource) Read(ctx context.Context, req datasource.ReadReque
 			resp.Diagnostics.Append(errorToDiagnostic(err, "failed to get repo"))
 			return
 		}
-		repoModel, diags := repoToModel(ctx, repo)
+		readme, err := d.repoReadme(ctx, repo.GetUid())
+		if err != nil {
+			resp.Diagnostics.Append(errorToDiagnostic(err, "failed to get repo readme"))
+			return
+		}
+		repoModel, diags := repoToModel(ctx, repo, readme)
 		resp.Diagnostics.Append(diags...)
 		if resp.Diagnostics.HasError() {
 			return
@@ -205,7 +211,12 @@ func (d *imageRepoDataSource) Read(ctx context.Context, req datasource.ReadReque
 		return
 	}
 	for _, repo := range repos {
-		repoModel, diags := repoToModel(ctx, repo)
+		readme, err := d.repoReadme(ctx, repo.GetUid())
+		if err != nil {
+			resp.Diagnostics.Append(errorToDiagnostic(err, "failed to get repo readme"))
+			return
+		}
+		repoModel, diags := repoToModel(ctx, repo, readme)
 		resp.Diagnostics.Append(diags...)
 		if resp.Diagnostics.HasError() {
 			return
@@ -223,7 +234,22 @@ func (d *imageRepoDataSource) Read(ctx context.Context, req datasource.ReadReque
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
 
-func repoToModel(ctx context.Context, repo *regv2.Repo) (*imageRepoModel, diag.Diagnostics) {
+// repoReadme looks up a repo's README via the v1 registry API, keyed by repo
+// UID. The README was dropped from the v2beta1 Repo surface, so v2beta1 reads
+// return an empty README. Source it from v1, which still returns it.
+func (d *dataSource) repoReadme(ctx context.Context, uid string) (string, error) {
+	list, err := d.prov.client.Registry().Registry().ListRepos(ctx, &registry.RepoFilter{Id: uid})
+	if err != nil {
+		return "", err
+	}
+	items := list.GetItems()
+	if len(items) == 0 {
+		return "", nil
+	}
+	return items[0].GetReadme(), nil
+}
+
+func repoToModel(ctx context.Context, repo *regv2.Repo, readme string) (*imageRepoModel, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
 	bundles, d := types.ListValueFrom(ctx, types.StringType, repo.GetBundles())
@@ -266,7 +292,7 @@ func repoToModel(ctx context.Context, repo *regv2.Repo) (*imageRepoModel, diag.D
 		ID:          types.StringValue(repo.GetUid()),
 		Name:        types.StringValue(repo.GetName()),
 		Bundles:     bundles,
-		Readme:      types.StringValue(repo.GetReadme()),
+		Readme:      types.StringValue(readme),
 		SyncConfig:  sc,
 		Tier:        types.StringValue(catalogTierString(repo.GetCatalogTier())),
 		Description: types.StringValue(repo.GetDescription()),

--- a/internal/provider/data_source_image_repos.go
+++ b/internal/provider/data_source_image_repos.go
@@ -163,7 +163,12 @@ func (d *imageReposDataSource) Read(ctx context.Context, req datasource.ReadRequ
 	data.Items = make([]*imageRepoModel, 0)
 
 	for _, repo := range repos {
-		repoModel, diags := repoToModel(ctx, repo)
+		readme, err := d.repoReadme(ctx, repo.GetUid())
+		if err != nil {
+			resp.Diagnostics.Append(errorToDiagnostic(err, "failed to get repo readme"))
+			return
+		}
+		repoModel, diags := repoToModel(ctx, repo, readme)
 		resp.Diagnostics.Append(diags...)
 		if resp.Diagnostics.HasError() {
 			return


### PR DESCRIPTION
The README was removed from the v2beta1 Repo surface, so the chainguard_image_repo data sources read it back as empty. Callers that round-trip that value into a full-repo update (notably the images-private tagger, which refreshes active_tags on every push) then overwrite the stored README with the empty string, silently wiping repo READMEs. Read the README from v1 instead, which still returns it, looked up by repo UID for an exact match.

Bump chainguard.dev/sdk to v0.1.89, where the readme field is already gone from the v2beta1 Repo type, so any future attempt to read it from v2beta1 fails to compile rather than silently regressing.
