### PR TITLE
feat: migrate IAM resources to v2beta1 SDK (CUS-320 Step 2)

### DIFF
--- a/internal/provider/data_source_role.go
+++ b/internal/provider/data_source_role.go
@@ -190,10 +190,7 @@ func (d *roleDataSource) Read(ctx context.Context, req datasource.ReadRequest, r
 func capabilityStrings(caps []capabilities.Capability) []string {
 	strs, err := capabilities.StringifyAll(caps)
 	if err != nil {
-		strs = make([]string, 0, len(caps))
-		for _, c := range caps {
-			strs = append(strs, c.String())
-		}
+		return nil
 	}
 	return strs
 }

--- a/internal/provider/data_source_role.go
+++ b/internal/provider/data_source_role.go
@@ -131,7 +131,12 @@ func (d *roleDataSource) Read(ctx context.Context, req datasource.ReadRequest, r
 			resp.Diagnostics.Append(errorToDiagnostic(err, "failed to get role"))
 			return
 		}
-		caps, diags := types.ListValueFrom(ctx, types.StringType, capabilityStrings(role.GetCapabilities()))
+		capStrs, err := capabilityStrings(role.GetCapabilities())
+		if err != nil {
+			resp.Diagnostics.Append(errorToDiagnostic(err, "failed to stringify capabilities"))
+			return
+		}
+		caps, diags := types.ListValueFrom(ctx, types.StringType, capStrs)
 		resp.Diagnostics.Append(diags...)
 		if resp.Diagnostics.HasError() {
 			return
@@ -160,7 +165,12 @@ func (d *roleDataSource) Read(ctx context.Context, req datasource.ReadRequest, r
 	}
 
 	for _, role := range roles {
-		caps, diags := types.ListValueFrom(ctx, types.StringType, capabilityStrings(role.GetCapabilities()))
+		capStrs, err := capabilityStrings(role.GetCapabilities())
+		if err != nil {
+			resp.Diagnostics.Append(errorToDiagnostic(err, "failed to stringify capabilities"))
+			return
+		}
+		caps, diags := types.ListValueFrom(ctx, types.StringType, capStrs)
 		resp.Diagnostics.Append(diags...)
 		if diags.HasError() {
 			tflog.Error(ctx, "failed to convert capabilities to basetypes.ListValue", map[string]any{"caps": role.GetCapabilities()})
@@ -187,10 +197,6 @@ func (d *roleDataSource) Read(ctx context.Context, req datasource.ReadRequest, r
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
 
-func capabilityStrings(caps []capabilities.Capability) []string {
-	strs, err := capabilities.StringifyAll(caps)
-	if err != nil {
-		return nil
-	}
-	return strs
+func capabilityStrings(caps []capabilities.Capability) ([]string, error) {
+	return capabilities.StringifyAll(caps)
 }

--- a/internal/provider/data_source_role.go
+++ b/internal/provider/data_source_role.go
@@ -188,9 +188,12 @@ func (d *roleDataSource) Read(ctx context.Context, req datasource.ReadRequest, r
 }
 
 func capabilityStrings(caps []capabilities.Capability) []string {
-	strs := make([]string, 0, len(caps))
-	for _, c := range caps {
-		strs = append(strs, c.String())
+	strs, err := capabilities.StringifyAll(caps)
+	if err != nil {
+		strs = make([]string, 0, len(caps))
+		for _, c := range caps {
+			strs = append(strs, c.String())
+		}
 	}
 	return strs
 }

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -414,10 +414,22 @@ func (pd *providerData) setupClient(ctx context.Context) error {
 	return nil
 }
 
-// setClient replaces the platform client under the mutex.
+// setClients replaces both v1 and v2beta1 clients under the mutex.
 // Used by resource_group after re-authenticating with a new organization scope.
-func (pd *providerData) setClient(clients platform.Clients) {
+func (pd *providerData) setClients(ctx context.Context, v1 platform.Clients) error {
 	pd.clientMu.Lock()
 	defer pd.clientMu.Unlock()
-	pd.client = clients
+	pd.client = v1
+
+	cgToken, err := token.Get(ctx, pd.loginConfig, false)
+	if err != nil {
+		return fmt.Errorf("failed to retrieve token for v2beta1 client refresh: %w", err)
+	}
+	cred := auth.NewFromToken(ctx, fmt.Sprintf("Bearer %s", string(cgToken)), false)
+	v2, err := clientsv2.NewClients(ctx, pd.consoleAPI, UserAgent, cred, retryDialOption())
+	if err != nil {
+		return fmt.Errorf("failed to create v2beta1 API clients: %w", err)
+	}
+	pd.clientV2 = v2
+	return nil
 }

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -417,10 +417,6 @@ func (pd *providerData) setupClient(ctx context.Context) error {
 // setClients replaces both v1 and v2beta1 clients under the mutex.
 // Used by resource_group after re-authenticating with a new organization scope.
 func (pd *providerData) setClients(ctx context.Context, v1 platform.Clients) error {
-	pd.clientMu.Lock()
-	defer pd.clientMu.Unlock()
-	pd.client = v1
-
 	cgToken, err := token.Get(ctx, pd.loginConfig, false)
 	if err != nil {
 		return fmt.Errorf("failed to retrieve token for v2beta1 client refresh: %w", err)
@@ -430,6 +426,14 @@ func (pd *providerData) setClients(ctx context.Context, v1 platform.Clients) err
 	if err != nil {
 		return fmt.Errorf("failed to create v2beta1 API clients: %w", err)
 	}
+
+	pd.clientMu.Lock()
+	defer pd.clientMu.Unlock()
+	old := pd.clientV2
+	pd.client = v1
 	pd.clientV2 = v2
+	if old != nil {
+		old.Close()
+	}
 	return nil
 }

--- a/internal/provider/provider_client_init_test.go
+++ b/internal/provider/provider_client_init_test.go
@@ -12,6 +12,15 @@ import (
 	platform "chainguard.dev/sdk/proto/platform"
 )
 
+// setClient is a test helper that sets only the v1 client under the mutex.
+// Production code uses setClients which also refreshes the v2beta1 client,
+// but these tests only exercise the mutex-protected swap pattern.
+func (pd *providerData) setClient(clients platform.Clients) {
+	pd.clientMu.Lock()
+	defer pd.clientMu.Unlock()
+	pd.client = clients
+}
+
 // TestSetClient_ThreadSafe verifies that setClient and the double-check
 // in setupClient work correctly under concurrent access.
 func TestSetClient_ThreadSafe(t *testing.T) {

--- a/internal/provider/resource_account_associations.go
+++ b/internal/provider/resource_account_associations.go
@@ -449,6 +449,8 @@ func (r *accountAssociationsResource) Read(ctx context.Context, req resource.Rea
 	if state.Description.ValueString() != assoc.Description {
 		state.Description = types.StringValue(assoc.Description)
 	}
+	// In v2beta1, AccountAssociation.Uid IS the parent group UIDP
+	// (one association per group, keyed by group).
 	if state.Group.ValueString() != assoc.GetUid() {
 		state.Group = types.StringValue(assoc.GetUid())
 	}

--- a/internal/provider/resource_account_associations.go
+++ b/internal/provider/resource_account_associations.go
@@ -26,6 +26,7 @@ import (
 
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/fieldmaskpb"
 
 	iamv2 "chainguard.dev/sdk/proto/chainguard/platform/iam/v2beta1"
 	"chainguard.dev/sdk/validation"
@@ -631,6 +632,7 @@ func (r *accountAssociationsResource) Update(ctx context.Context, req resource.U
 	assoc.Uid = data.ID.ValueString()
 	_, err := r.prov.clientV2.IAM().AccountAssociationsService().UpdateAccountAssociation(ctx, &iamv2.UpdateAccountAssociationRequest{
 		AccountAssociation: assoc,
+		UpdateMask:         &fieldmaskpb.FieldMask{Paths: []string{"*"}},
 	})
 	if err != nil {
 		resp.Diagnostics.Append(errorToDiagnostic(err, "failed to update account associations"))

--- a/internal/provider/resource_account_associations.go
+++ b/internal/provider/resource_account_associations.go
@@ -633,13 +633,16 @@ func (r *accountAssociationsResource) Delete(ctx context.Context, req resource.D
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	id := state.Group.ValueString()
+	id := state.ID.ValueString()
 	tflog.Info(ctx, fmt.Sprintf("delete account associations request for group: %s", id))
 
 	_, err := r.prov.clientV2.IAM().AccountAssociationsService().DeleteAccountAssociation(ctx, &iamv2.DeleteAccountAssociationRequest{
 		Uid: id,
 	})
 	if err != nil {
-		resp.Diagnostics.Append(errorToDiagnostic(err, fmt.Sprintf("failed to account associations for group %q", id)))
+		if status.Code(err) == codes.NotFound {
+			return
+		}
+		resp.Diagnostics.Append(errorToDiagnostic(err, fmt.Sprintf("failed to delete account associations for group %q", id)))
 	}
 }

--- a/internal/provider/resource_account_associations.go
+++ b/internal/provider/resource_account_associations.go
@@ -24,7 +24,10 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
-	iam "chainguard.dev/sdk/proto/platform/iam/v1"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	iamv2 "chainguard.dev/sdk/proto/chainguard/platform/iam/v2beta1"
 	"chainguard.dev/sdk/validation"
 	"github.com/chainguard-dev/terraform-provider-chainguard/internal/validators"
 	"github.com/hashicorp/terraform-plugin-framework-validators/objectvalidator"
@@ -273,11 +276,10 @@ func (r *accountAssociationsResource) ImportState(ctx context.Context, req resou
 	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
 }
 
-func populateAccountAssociation(ctx context.Context, m accountAssociationsResourceModel) (*iam.AccountAssociations, diag.Diagnostics) {
-	assoc := &iam.AccountAssociations{
+func populateAccountAssociation(ctx context.Context, m accountAssociationsResourceModel) (*iamv2.AccountAssociation, diag.Diagnostics) {
+	assoc := &iamv2.AccountAssociation{
 		Name:        m.Name.ValueString(),
 		Description: m.Description.ValueString(),
-		Group:       m.Group.ValueString(),
 	}
 
 	var diags diag.Diagnostics
@@ -287,7 +289,7 @@ func populateAccountAssociation(ctx context.Context, m accountAssociationsResour
 			return nil, diags
 		}
 
-		assoc.Amazon = &iam.AccountAssociations_Amazon{
+		assoc.Amazon = &iamv2.AccountAssociation_Amazon{
 			Account: am.Account.ValueString(),
 		}
 	}
@@ -303,7 +305,7 @@ func populateAccountAssociation(ctx context.Context, m accountAssociationsResour
 			return nil, diags
 		}
 
-		assoc.Chainguard = &iam.AccountAssociations_Chainguard{
+		assoc.Chainguard = &iamv2.AccountAssociation_Chainguard{
 			ServiceBindings: sb,
 		}
 	}
@@ -314,7 +316,7 @@ func populateAccountAssociation(ctx context.Context, m accountAssociationsResour
 			return nil, diags
 		}
 
-		assoc.Google = &iam.AccountAssociations_Google{
+		assoc.Google = &iamv2.AccountAssociation_Google{
 			ProjectId:     gm.ProjectID.ValueString(),
 			ProjectNumber: gm.ProjectNumber.ValueString(),
 		}
@@ -330,10 +332,10 @@ func populateAccountAssociation(ctx context.Context, m accountAssociationsResour
 				"The github block now requires app_id. Set it to the GitHub App ID, or migrate to github_installation blocks.")
 			return nil, diags
 		}
-		assoc.Github = &iam.AccountAssociations_GitHub{
-			AppInstallations: map[int64]*iam.AccountAssociations_GitHubAppInstallations{
+		assoc.Github = &iamv2.AccountAssociation_GitHub{
+			AppInstallations: map[int64]*iamv2.AccountAssociation_GitHubAppInstallations{
 				gm.AppID.ValueInt64(): {
-					Installations: []*iam.AccountAssociations_GitHubInstallation{{
+					Installations: []*iamv2.AccountAssociation_GitHubInstallation{{
 						InstallationId: gm.InstallationID.ValueInt64(),
 						Name:           gm.Name.ValueString(),
 					}},
@@ -343,18 +345,18 @@ func populateAccountAssociation(ctx context.Context, m accountAssociationsResour
 	}
 
 	if len(m.GithubInstallation) > 0 {
-		appInstalls := make(map[int64]*iam.AccountAssociations_GitHubAppInstallations, len(m.GithubInstallation))
+		appInstalls := make(map[int64]*iamv2.AccountAssociation_GitHubAppInstallations, len(m.GithubInstallation))
 		for _, gh := range m.GithubInstallation {
 			appID := gh.AppID.ValueInt64()
 			if appInstalls[appID] == nil {
-				appInstalls[appID] = &iam.AccountAssociations_GitHubAppInstallations{}
+				appInstalls[appID] = &iamv2.AccountAssociation_GitHubAppInstallations{}
 			}
-			appInstalls[appID].Installations = append(appInstalls[appID].Installations, &iam.AccountAssociations_GitHubInstallation{
+			appInstalls[appID].Installations = append(appInstalls[appID].Installations, &iamv2.AccountAssociation_GitHubInstallation{
 				InstallationId: gh.InstallationID.ValueInt64(),
 				Name:           gh.Name.ValueString(),
 			})
 		}
-		assoc.Github = &iam.AccountAssociations_GitHub{
+		assoc.Github = &iamv2.AccountAssociation_GitHub{
 			AppInstallations: appInstalls,
 		}
 	}
@@ -369,7 +371,7 @@ func populateAccountAssociation(ctx context.Context, m accountAssociationsResour
 		if diags.HasError() {
 			return nil, diags
 		}
-		assoc.Azure = &iam.AccountAssociations_Azure{
+		assoc.Azure = &iamv2.AccountAssociation_Azure{
 			TenantId:  am.TenantID.ValueString(),
 			ClientIds: m,
 		}
@@ -396,8 +398,11 @@ func (r *accountAssociationsResource) Create(ctx context.Context, req resource.C
 
 	// Retry on PermissionDenied to handle eventual consistency when the
 	// parent group was just created in the same apply.
-	created, err := retryOnPermissionDenied(ctx, func() (*iam.AccountAssociations, error) {
-		return r.prov.client.IAM().AccountAssociations().Create(ctx, assoc)
+	created, err := retryOnPermissionDenied(ctx, func() (*iamv2.AccountAssociation, error) {
+		return r.prov.clientV2.IAM().AccountAssociationsService().CreateAccountAssociation(ctx, &iamv2.CreateAccountAssociationRequest{
+			Parent:             plan.Group.ValueString(),
+			AccountAssociation: assoc,
+		})
 	})
 	if err != nil {
 		resp.Diagnostics.Append(errorToDiagnostic(err, "failed to create account association"))
@@ -405,9 +410,7 @@ func (r *accountAssociationsResource) Create(ctx context.Context, req resource.C
 	}
 
 	// Save account association details in the state.
-	// Account associations have no "id". They are one per group so we use the
-	// group as id.
-	plan.ID = types.StringValue(created.Group)
+	plan.ID = types.StringValue(created.GetUid())
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
 }
 
@@ -425,25 +428,18 @@ func (r *accountAssociationsResource) Read(ctx context.Context, req resource.Rea
 	id := state.ID.ValueString()
 	tflog.Info(ctx, fmt.Sprintf("read account association request for group: %s", id))
 
-	assocList, err := r.prov.client.IAM().AccountAssociations().List(ctx, &iam.AccountAssociationsFilter{
-		Group: id,
+	assoc, err := r.prov.clientV2.IAM().AccountAssociationsService().GetAccountAssociation(ctx, &iamv2.GetAccountAssociationRequest{
+		Uid: id,
 	})
 	if err != nil {
-		resp.Diagnostics.Append(errorToDiagnostic(err, "failed to list account associations"))
+		if status.Code(err) == codes.NotFound {
+			// Account association was deleted outside TF, remove from state
+			resp.State.RemoveResource(ctx)
+			return
+		}
+		resp.Diagnostics.Append(errorToDiagnostic(err, "failed to get account association"))
 		return
 	}
-
-	switch c := len(assocList.GetItems()); {
-	case c == 0:
-		// Account association was deleted outside TF, remove from state
-		resp.State.RemoveResource(ctx)
-		return
-	case c > 1:
-		resp.Diagnostics.AddError("failed to list account associations", fmt.Sprintf("more than one account association found matching group id %s", id))
-		return
-	}
-
-	assoc := assocList.GetItems()[0]
 
 	// Only update the state model if there are differences returned from the API
 	// to prevent Terraform reporting extraneous drift.
@@ -453,8 +449,8 @@ func (r *accountAssociationsResource) Read(ctx context.Context, req resource.Rea
 	if state.Description.ValueString() != assoc.Description {
 		state.Description = types.StringValue(assoc.Description)
 	}
-	if state.Group.ValueString() != assoc.Group {
-		state.Group = types.StringValue(assoc.Group)
+	if state.Group.ValueString() != assoc.GetUid() {
+		state.Group = types.StringValue(assoc.GetUid())
 	}
 
 	var diags diag.Diagnostics
@@ -617,7 +613,10 @@ func (r *accountAssociationsResource) Update(ctx context.Context, req resource.U
 		return
 	}
 
-	_, err := r.prov.client.IAM().AccountAssociations().Update(ctx, assoc)
+	assoc.Uid = data.ID.ValueString()
+	_, err := r.prov.clientV2.IAM().AccountAssociationsService().UpdateAccountAssociation(ctx, &iamv2.UpdateAccountAssociationRequest{
+		AccountAssociation: assoc,
+	})
 	if err != nil {
 		resp.Diagnostics.Append(errorToDiagnostic(err, "failed to update account associations"))
 		return
@@ -637,8 +636,8 @@ func (r *accountAssociationsResource) Delete(ctx context.Context, req resource.D
 	id := state.Group.ValueString()
 	tflog.Info(ctx, fmt.Sprintf("delete account associations request for group: %s", id))
 
-	_, err := r.prov.client.IAM().AccountAssociations().Delete(ctx, &iam.DeleteAccountAssociationsRequest{
-		Group: id,
+	_, err := r.prov.clientV2.IAM().AccountAssociationsService().DeleteAccountAssociation(ctx, &iamv2.DeleteAccountAssociationRequest{
+		Uid: id,
 	})
 	if err != nil {
 		resp.Diagnostics.Append(errorToDiagnostic(err, fmt.Sprintf("failed to account associations for group %q", id)))

--- a/internal/provider/resource_account_associations.go
+++ b/internal/provider/resource_account_associations.go
@@ -472,6 +472,8 @@ func (r *accountAssociationsResource) Read(ctx context.Context, req resource.Rea
 			state.Amazon, diags = types.ObjectValueFrom(ctx, state.Amazon.AttributeTypes(ctx), am)
 			resp.Diagnostics.Append(diags...)
 		}
+	} else if !state.Amazon.IsNull() {
+		state.Amazon = types.ObjectNull(state.Amazon.AttributeTypes(ctx))
 	}
 
 	if assoc.Chainguard != nil {
@@ -500,6 +502,8 @@ func (r *accountAssociationsResource) Read(ctx context.Context, req resource.Rea
 			state.Chainguard, diags = types.ObjectValueFrom(ctx, state.Chainguard.AttributeTypes(ctx), cm)
 			resp.Diagnostics.Append(diags...)
 		}
+	} else if !state.Chainguard.IsNull() {
+		state.Chainguard = types.ObjectNull(state.Chainguard.AttributeTypes(ctx))
 	}
 
 	if assoc.Google != nil {
@@ -519,6 +523,8 @@ func (r *accountAssociationsResource) Read(ctx context.Context, req resource.Rea
 			state.Google, diags = types.ObjectValueFrom(ctx, state.Google.AttributeTypes(ctx), gm)
 			resp.Diagnostics.Append(diags...)
 		}
+	} else if !state.Google.IsNull() {
+		state.Google = types.ObjectNull(state.Google.AttributeTypes(ctx))
 	}
 
 	if assoc.Azure != nil {
@@ -539,6 +545,8 @@ func (r *accountAssociationsResource) Read(ctx context.Context, req resource.Rea
 			state.Azure, diags = types.ObjectValueFrom(ctx, state.Azure.AttributeTypes(ctx), am)
 			resp.Diagnostics.Append(diags...)
 		}
+	} else if !state.Azure.IsNull() {
+		state.Azure = types.ObjectNull(state.Azure.AttributeTypes(ctx))
 	}
 
 	if assoc.Github != nil {
@@ -576,6 +584,11 @@ func (r *accountAssociationsResource) Read(ctx context.Context, req resource.Rea
 				}
 			}
 		}
+	} else {
+		if !state.Github.IsNull() {
+			state.Github = types.ObjectNull(state.Github.AttributeTypes(ctx))
+		}
+		state.GithubInstallation = nil
 	}
 
 	if resp.Diagnostics.HasError() {

--- a/internal/provider/resource_group.go
+++ b/internal/provider/resource_group.go
@@ -23,8 +23,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
+	iamv2 "chainguard.dev/sdk/proto/chainguard/platform/iam/v2beta1"
 	"chainguard.dev/sdk/proto/platform"
-	common "chainguard.dev/sdk/proto/platform/common/v1"
 	iam "chainguard.dev/sdk/proto/platform/iam/v1"
 	"chainguard.dev/sdk/uidp"
 	"github.com/chainguard-dev/terraform-provider-chainguard/internal/protoutil"
@@ -126,8 +126,8 @@ func (r *groupResource) Create(ctx context.Context, req resource.CreateRequest, 
 	tflog.Info(ctx, fmt.Sprintf("create group request: name=%s, parent_id=%s", plan.Name, plan.ParentID))
 
 	// Create the group.
-	cr := &iam.CreateGroupRequest{
-		Group: &iam.Group{
+	cr := &iamv2.CreateGroupRequest{
+		Group: &iamv2.Group{
 			Name:        plan.Name.ValueString(),
 			Description: plan.Description.ValueString(),
 			Verified:    plan.Verified.ValueBool(),
@@ -139,16 +139,16 @@ func (r *groupResource) Create(ctx context.Context, req resource.CreateRequest, 
 		cr.Parent = plan.ParentID.ValueString()
 	}
 
-	g, err := r.prov.client.IAM().Groups().Create(ctx, cr)
+	g, err := r.prov.clientV2.IAM().GroupsService().CreateGroup(ctx, cr)
 	if err != nil {
 		resp.Diagnostics.Append(errorToDiagnostic(err, fmt.Sprintf("failed to create group %q", cr.Group.Name)))
 		return
 	}
 
 	// Save group details in the state.
-	plan.ID = types.StringValue(g.Id)
-	if len(g.ResourceLimits) > 0 {
-		rl, diags := types.MapValueFrom(ctx, types.Int32Type, g.ResourceLimits)
+	plan.ID = types.StringValue(g.GetUid())
+	if len(g.GetResourceLimits()) > 0 {
+		rl, diags := types.MapValueFrom(ctx, types.Int32Type, g.GetResourceLimits())
 		resp.Diagnostics.Append(diags...)
 		if resp.Diagnostics.HasError() {
 			return
@@ -161,11 +161,11 @@ func (r *groupResource) Create(ctx context.Context, req resource.CreateRequest, 
 
 	// Attempt to reauthenticate if an organization was created so token
 	// has new organization in scope.
-	if uidp.InRoot(g.Id) {
+	if uidp.InRoot(g.GetUid()) {
 		cfg := r.prov.loginConfig
-		clients, err := r.waitForRoleBindingPropagation(ctx, g.Id, cfg)
+		clients, err := r.waitForRoleBindingPropagation(ctx, g.GetUid(), cfg)
 		if err != nil {
-			resp.Diagnostics.Append(errorToDiagnostic(err, fmt.Sprintf("failed to verify root group access for %q", g.Id)))
+			resp.Diagnostics.Append(errorToDiagnostic(err, fmt.Sprintf("failed to verify root group access for %q", g.GetUid())))
 			return
 		}
 		r.prov.setClient(clients)
@@ -174,6 +174,8 @@ func (r *groupResource) Create(ctx context.Context, req resource.CreateRequest, 
 
 // waitForRoleBindingPropagation waits for role binding propagation after organization creation.
 // It polls the API with exponential backoff until the group is accessible or times out.
+// NB: This uses v1 clients because it creates fresh platform.Clients via newPlatformClients,
+// which only constructs v1 clients. This is a transient retry mechanism, not a core CRUD path.
 func (r *groupResource) waitForRoleBindingPropagation(
 	ctx context.Context,
 	groupID string,
@@ -260,64 +262,51 @@ func (r *groupResource) Read(ctx context.Context, req resource.ReadRequest, resp
 	}
 	tflog.Info(ctx, fmt.Sprintf("read group request: %s", state.ID))
 
-	// Query for the group to update state
-	uf := &common.UIDPFilter{}
-	if uidp.Valid(state.ParentID.ValueString()) {
-		uf.ChildrenOf = state.ParentID.ValueString()
-	}
-	f := &iam.GroupFilter{
-		Id:   state.ID.ValueString(),
-		Name: state.Name.ValueString(),
-		Uidp: uf,
-	}
-	groupList, err := r.prov.client.IAM().Groups().List(ctx, f)
+	// Query for the group using GetGroup instead of List-by-ID.
+	groupID := state.ID.ValueString()
+	g, err := r.prov.clientV2.IAM().GroupsService().GetGroup(ctx, &iamv2.GetGroupRequest{
+		Uid: groupID,
+	})
 	if err != nil {
-		resp.Diagnostics.Append(errorToDiagnostic(err, "failed to list groups"))
+		if status.Code(err) == codes.NotFound {
+			// Group was already deleted outside TF, remove from state
+			resp.State.RemoveResource(ctx)
+			return
+		}
+		resp.Diagnostics.Append(errorToDiagnostic(err, "failed to get group"))
 		return
 	}
 
-	switch c := len(groupList.GetItems()); c {
-	case 0:
-		// Group was already deleted outside TF, remove from state
-		resp.State.RemoveResource(ctx)
-
-	case 1:
-		g := groupList.GetItems()[0]
-		state.ID = types.StringValue(g.Id)
-		state.Name = types.StringValue(g.Name)
-		// Only update the state description if it started as non-null or we receive a description.
-		if !state.Description.IsNull() || g.Description != "" {
-			state.Description = types.StringValue(g.Description)
-		}
-		// Allow ParentID to remain null for organizations, but ensure it is populated
-		// for when importing folders.
-		if !state.ParentID.IsNull() || !uidp.InRoot(g.Id) {
-			state.ParentID = types.StringValue(uidp.Parent(g.Id))
-		}
-		// Keep null verified fields null for backward compatibility
-		// if it hasn't changed upstream.
-		if !state.Verified.IsNull() || g.Verified {
-			state.Verified = types.BoolValue(g.Verified)
-		}
-
-		if len(g.ResourceLimits) > 0 {
-			rl, diags := types.MapValueFrom(ctx, types.Int32Type, g.ResourceLimits)
-			resp.Diagnostics.Append(diags...)
-			if resp.Diagnostics.HasError() {
-				return
-			}
-			state.ResourceLimits = rl
-		} else {
-			state.ResourceLimits = types.MapNull(types.Int32Type)
-		}
-
-		// Set state
-		resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
-
-	default:
-		tflog.Error(ctx, fmt.Sprintf("group list returned %d groups for filter %v", c, f))
-		resp.Diagnostics.AddError("more than one group found matching filters", fmt.Sprintf("filters=%v\nPlease provide more context to narrow query (e.g. parent_id).", state))
+	state.ID = types.StringValue(g.GetUid())
+	state.Name = types.StringValue(g.GetName())
+	// Only update the state description if it started as non-null or we receive a description.
+	if !state.Description.IsNull() || g.GetDescription() != "" {
+		state.Description = types.StringValue(g.GetDescription())
 	}
+	// Allow ParentID to remain null for organizations, but ensure it is populated
+	// for when importing folders.
+	if !state.ParentID.IsNull() || !uidp.InRoot(g.GetUid()) {
+		state.ParentID = types.StringValue(uidp.Parent(g.GetUid()))
+	}
+	// Keep null verified fields null for backward compatibility
+	// if it hasn't changed upstream.
+	if !state.Verified.IsNull() || g.GetVerified() {
+		state.Verified = types.BoolValue(g.GetVerified())
+	}
+
+	if len(g.GetResourceLimits()) > 0 {
+		rl, diags := types.MapValueFrom(ctx, types.Int32Type, g.GetResourceLimits())
+		resp.Diagnostics.Append(diags...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+		state.ResourceLimits = rl
+	} else {
+		state.ResourceLimits = types.MapNull(types.Int32Type)
+	}
+
+	// Set state
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 }
 
 func (r *groupResource) update(ctx context.Context, data *groupResourceModel, state groupResourceModel) diag.Diagnostic {
@@ -330,27 +319,29 @@ func (r *groupResource) update(ctx context.Context, data *groupResourceModel, st
 		return diag.NewErrorDiagnostic("cannot unverify group", fmt.Sprintf("group %s is verified and verified_protection is true or null; apply verified_protection = false before attempting to unverify this group", state.ID.ValueString()))
 	}
 
-	g, err := r.prov.client.IAM().Groups().Update(ctx, &iam.Group{
-		Id:          data.ID.ValueString(),
-		Name:        data.Name.ValueString(),
-		Description: data.Description.ValueString(),
-		Verified:    data.Verified.ValueBool(),
+	g, err := r.prov.clientV2.IAM().GroupsService().UpdateGroup(ctx, &iamv2.UpdateGroupRequest{
+		Group: &iamv2.Group{
+			Uid:         data.ID.ValueString(),
+			Name:        data.Name.ValueString(),
+			Description: data.Description.ValueString(),
+			Verified:    data.Verified.ValueBool(),
+		},
 	})
 	if err != nil {
 		return errorToDiagnostic(err, fmt.Sprintf("failed to update group %q", data.ID.ValueString()))
 	}
 
 	// Update data from the returned value.
-	data.ID = types.StringValue(g.Id)
+	data.ID = types.StringValue(g.GetUid())
 	data.Name = types.StringValue(g.GetName())
-	if !data.Description.IsNull() || g.Description != "" {
+	if !data.Description.IsNull() || g.GetDescription() != "" {
 		data.Description = types.StringValue(g.GetDescription())
 	}
-	if !data.Verified.IsNull() || g.Verified {
-		data.Verified = types.BoolValue(g.Verified)
+	if !data.Verified.IsNull() || g.GetVerified() {
+		data.Verified = types.BoolValue(g.GetVerified())
 	}
-	if len(g.ResourceLimits) > 0 {
-		rl, diags := types.MapValueFrom(ctx, types.Int32Type, g.ResourceLimits)
+	if len(g.GetResourceLimits()) > 0 {
+		rl, diags := types.MapValueFrom(ctx, types.Int32Type, g.GetResourceLimits())
 		if diags.HasError() {
 			return diags[0]
 		}
@@ -398,8 +389,8 @@ func (r *groupResource) Delete(ctx context.Context, req resource.DeleteRequest, 
 	tflog.Info(ctx, fmt.Sprintf("delete group request: %s", state.ID))
 
 	id := state.ID.ValueString()
-	_, err := r.prov.client.IAM().Groups().Delete(ctx, &iam.DeleteGroupRequest{
-		Id: id,
+	_, err := r.prov.clientV2.IAM().GroupsService().DeleteGroup(ctx, &iamv2.DeleteGroupRequest{
+		Uid: id,
 	})
 	if err != nil {
 		resp.Diagnostics.Append(errorToDiagnostic(err, fmt.Sprintf("failed to delete group %q", id)))

--- a/internal/provider/resource_group.go
+++ b/internal/provider/resource_group.go
@@ -168,7 +168,10 @@ func (r *groupResource) Create(ctx context.Context, req resource.CreateRequest, 
 			resp.Diagnostics.Append(errorToDiagnostic(err, fmt.Sprintf("failed to verify root group access for %q", g.GetUid())))
 			return
 		}
-		r.prov.setClient(clients)
+		if err := r.prov.setClients(ctx, clients); err != nil {
+			resp.Diagnostics.Append(errorToDiagnostic(err, fmt.Sprintf("failed to refresh clients for %q", g.GetUid())))
+			return
+		}
 	}
 }
 
@@ -393,6 +396,9 @@ func (r *groupResource) Delete(ctx context.Context, req resource.DeleteRequest, 
 		Uid: id,
 	})
 	if err != nil {
+		if status.Code(err) == codes.NotFound {
+			return
+		}
 		resp.Diagnostics.Append(errorToDiagnostic(err, fmt.Sprintf("failed to delete group %q", id)))
 		return
 	}

--- a/internal/provider/resource_group_invite.go
+++ b/internal/provider/resource_group_invite.go
@@ -19,9 +19,11 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/durationpb"
 
-	iam "chainguard.dev/sdk/proto/platform/iam/v1"
+	iamv2 "chainguard.dev/sdk/proto/chainguard/platform/iam/v2beta1"
 	"github.com/chainguard-dev/terraform-provider-chainguard/internal/validators"
 )
 
@@ -148,12 +150,14 @@ func (r *groupInviteResource) Create(ctx context.Context, req resource.CreateReq
 
 	// Retry on PermissionDenied to handle eventual consistency when the
 	// parent group was just created in the same apply.
-	invite, err := retryOnPermissionDenied(ctx, func() (*iam.GroupInvite, error) {
-		return r.prov.client.IAM().GroupInvites().Create(ctx, &iam.GroupInviteRequest{
-			Group: plan.Group.ValueString(),
-			Ttl:   durationpb.New(time.Until(ts)),
-			Role:  plan.Role.ValueString(),
-			Email: plan.Email.ValueString(),
+	invite, err := retryOnPermissionDenied(ctx, func() (*iamv2.GroupInvite, error) {
+		return r.prov.clientV2.IAM().GroupInvitesService().CreateGroupInvite(ctx, &iamv2.CreateGroupInviteRequest{
+			Parent: plan.Group.ValueString(),
+			GroupInvite: &iamv2.GroupInvite{
+				Ttl:     durationpb.New(time.Until(ts)),
+				RoleUid: plan.Role.ValueString(),
+				Email:   plan.Email.ValueString(),
+			},
 		})
 	})
 	if err != nil {
@@ -162,8 +166,8 @@ func (r *groupInviteResource) Create(ctx context.Context, req resource.CreateReq
 	}
 
 	// Save group invite details in the state.
-	plan.ID = types.StringValue(invite.Id)
-	plan.Code = types.StringValue(invite.Code)
+	plan.ID = types.StringValue(invite.GetUid())
+	plan.Code = types.StringValue(invite.GetCode())
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
 }
 
@@ -177,30 +181,22 @@ func (r *groupInviteResource) Read(ctx context.Context, req resource.ReadRequest
 	}
 	tflog.Info(ctx, fmt.Sprintf("read group invite request: %s", state.ID))
 
-	// Query for the group to update state
-	inviteList, err := r.prov.client.IAM().GroupInvites().List(ctx, &iam.GroupInviteFilter{
-		Id: state.ID.ValueString(),
+	// Query for the group invite using GetGroupInvite instead of List-by-ID.
+	_, err := r.prov.clientV2.IAM().GroupInvitesService().GetGroupInvite(ctx, &iamv2.GetGroupInviteRequest{
+		Uid: state.ID.ValueString(),
 	})
 	if err != nil {
-		resp.Diagnostics.Append(errorToDiagnostic(err, "failed to list group invites"))
+		if status.Code(err) == codes.NotFound {
+			// Group invite was deleted outside TF, remove from state
+			resp.State.RemoveResource(ctx)
+			return
+		}
+		resp.Diagnostics.Append(errorToDiagnostic(err, "failed to get group invite"))
 		return
 	}
 
-	switch c := len(inviteList.GetItems()); c {
-	case 0:
-		// Group was already deleted outside TF, remove from state
-		resp.State.RemoveResource(ctx)
-
-	case 1:
-		// TODO: We cannot read the code, so are there any useful fields to set?
-
-		// Set state
-		resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
-
-	default:
-		tflog.Error(ctx, fmt.Sprintf("group invite list returned %d invites for id %s", c, state.ID.ValueString()))
-		resp.Diagnostics.AddError("failed to list group invites", fmt.Sprintf("more than one group invite found matching id %s", state.ID.ValueString()))
-	}
+	// Set state — we cannot read the code, so just confirm existence.
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 }
 
 // Update updates the resource and sets the updated Terraform state on success.
@@ -219,8 +215,8 @@ func (r *groupInviteResource) Delete(ctx context.Context, req resource.DeleteReq
 	tflog.Info(ctx, fmt.Sprintf("delete group invite request: %s", state.ID))
 
 	id := state.ID.ValueString()
-	_, err := r.prov.client.IAM().GroupInvites().Delete(ctx, &iam.DeleteGroupInviteRequest{
-		Id: state.ID.ValueString(),
+	_, err := r.prov.clientV2.IAM().GroupInvitesService().DeleteGroupInvite(ctx, &iamv2.DeleteGroupInviteRequest{
+		Uid: id,
 	})
 	if err != nil {
 		resp.Diagnostics.Append(errorToDiagnostic(err, fmt.Sprintf("failed to delete group invite %q", id)))

--- a/internal/provider/resource_group_invite.go
+++ b/internal/provider/resource_group_invite.go
@@ -219,6 +219,9 @@ func (r *groupInviteResource) Delete(ctx context.Context, req resource.DeleteReq
 		Uid: id,
 	})
 	if err != nil {
+		if status.Code(err) == codes.NotFound {
+			return
+		}
 		resp.Diagnostics.Append(errorToDiagnostic(err, fmt.Sprintf("failed to delete group invite %q", id)))
 	}
 }

--- a/internal/provider/resource_group_test.go
+++ b/internal/provider/resource_group_test.go
@@ -17,11 +17,26 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 
-	iam "chainguard.dev/sdk/proto/platform/iam/v1"
-	iamtest "chainguard.dev/sdk/proto/platform/iam/v1/test"
-	platformtest "chainguard.dev/sdk/proto/platform/test"
+	clientsv2 "chainguard.dev/sdk/proto/chainguard/platform/clients/v2beta1"
+	iamv2 "chainguard.dev/sdk/proto/chainguard/platform/iam/v2beta1"
+	iamv2test "chainguard.dev/sdk/proto/chainguard/platform/iam/v2beta1/test"
+	registry "chainguard.dev/sdk/proto/chainguard/platform/registry/v2beta1"
+	"chainguard.dev/sdk/proto/chainguard/platform/test"
+	vuln "chainguard.dev/sdk/proto/chainguard/platform/vulnerabilities/v2beta1"
 	"github.com/chainguard-dev/clog/slogtest"
 )
+
+// mockV2PlatformClients implements clientsv2.Clients for unit tests.
+type mockV2PlatformClients struct {
+	iamClients iamv2.Clients
+}
+
+var _ clientsv2.Clients = (*mockV2PlatformClients)(nil)
+
+func (m *mockV2PlatformClients) IAM() iamv2.Clients            { return m.iamClients }
+func (m *mockV2PlatformClients) Registry() registry.Clients    { return nil }
+func (m *mockV2PlatformClients) Vulnerabilities() vuln.Clients { return nil }
+func (m *mockV2PlatformClients) Close() error                  { return nil }
 
 func testAccResourceGroup(parent, name, description string) string {
 	const tmpl = `
@@ -46,25 +61,25 @@ resource "chainguard_group" "test" {
 
 func TestGroupResource_update(t *testing.T) {
 	for _, c := range []struct {
-		name     string
-		onUpdate iamtest.GroupOnUpdate
-		data     groupResourceModel
-		state    groupResourceModel
-		wantDiag diag.Diagnostic
+		name          string
+		onUpdateGroup test.On[*iamv2.UpdateGroupRequest, *iamv2.Group]
+		data          groupResourceModel
+		state         groupResourceModel
+		wantDiag      diag.Diagnostic
 	}{{
 		name: "update description",
-		onUpdate: iamtest.GroupOnUpdate{
-			Given: &iam.Group{
-				Id:          "id",
-				Name:        "name",
-				Description: "foo",
-				Verified:    false,
+		onUpdateGroup: test.On[*iamv2.UpdateGroupRequest, *iamv2.Group]{
+			Given: &iamv2.UpdateGroupRequest{
+				Group: &iamv2.Group{
+					Uid:         "id",
+					Name:        "name",
+					Description: "foo",
+				},
 			},
-			Updated: &iam.Group{
-				Id:          "id",
+			Result: &iamv2.Group{
+				Uid:         "id",
 				Name:        "name",
 				Description: "foo",
-				Verified:    false,
 			},
 		},
 		data: groupResourceModel{
@@ -79,14 +94,16 @@ func TestGroupResource_update(t *testing.T) {
 		},
 	}, {
 		name: "set verified when null",
-		onUpdate: iamtest.GroupOnUpdate{
-			Given: &iam.Group{
-				Id:       "id",
-				Name:     "name",
-				Verified: true,
+		onUpdateGroup: test.On[*iamv2.UpdateGroupRequest, *iamv2.Group]{
+			Given: &iamv2.UpdateGroupRequest{
+				Group: &iamv2.Group{
+					Uid:      "id",
+					Name:     "name",
+					Verified: true,
+				},
 			},
-			Updated: &iam.Group{
-				Id:       "id",
+			Result: &iamv2.Group{
+				Uid:      "id",
 				Name:     "name",
 				Verified: true,
 			},
@@ -103,14 +120,16 @@ func TestGroupResource_update(t *testing.T) {
 		},
 	}, {
 		name: "set verified when false",
-		onUpdate: iamtest.GroupOnUpdate{
-			Given: &iam.Group{
-				Id:       "id",
-				Name:     "name",
-				Verified: true,
+		onUpdateGroup: test.On[*iamv2.UpdateGroupRequest, *iamv2.Group]{
+			Given: &iamv2.UpdateGroupRequest{
+				Group: &iamv2.Group{
+					Uid:      "id",
+					Name:     "name",
+					Verified: true,
+				},
 			},
-			Updated: &iam.Group{
-				Id:       "id",
+			Result: &iamv2.Group{
+				Uid:      "id",
 				Name:     "name",
 				Verified: true,
 			},
@@ -128,16 +147,16 @@ func TestGroupResource_update(t *testing.T) {
 		},
 	}, {
 		name: "unverify with verified_protection false",
-		onUpdate: iamtest.GroupOnUpdate{
-			Given: &iam.Group{
-				Id:       "id",
-				Name:     "name",
-				Verified: false,
+		onUpdateGroup: test.On[*iamv2.UpdateGroupRequest, *iamv2.Group]{
+			Given: &iamv2.UpdateGroupRequest{
+				Group: &iamv2.Group{
+					Uid:  "id",
+					Name: "name",
+				},
 			},
-			Updated: &iam.Group{
-				Id:       "id",
-				Name:     "name",
-				Verified: false,
+			Result: &iamv2.Group{
+				Uid:  "id",
+				Name: "name",
 			},
 		},
 		data: groupResourceModel{
@@ -183,13 +202,15 @@ func TestGroupResource_update(t *testing.T) {
 		wantDiag: diag.NewErrorDiagnostic("cannot unverify group", "group id is verified and verified_protection is true or null; apply verified_protection = false before attempting to unverify this group"),
 	}, {
 		name: "update sets resource_limits to null when empty",
-		onUpdate: iamtest.GroupOnUpdate{
-			Given: &iam.Group{
-				Id:   "id",
-				Name: "name",
+		onUpdateGroup: test.On[*iamv2.UpdateGroupRequest, *iamv2.Group]{
+			Given: &iamv2.UpdateGroupRequest{
+				Group: &iamv2.Group{
+					Uid:  "id",
+					Name: "name",
+				},
 			},
-			Updated: &iam.Group{
-				Id:   "id",
+			Result: &iamv2.Group{
+				Uid:  "id",
 				Name: "name",
 			},
 		},
@@ -208,10 +229,11 @@ func TestGroupResource_update(t *testing.T) {
 			r := &groupResource{
 				managedResource: managedResource{
 					prov: &providerData{
-						client: platformtest.MockPlatformClients{
-							IAMClient: iamtest.MockIAMClient{
-								GroupsClient: iamtest.MockGroupsClient{
-									OnUpdate: []iamtest.GroupOnUpdate{c.onUpdate},
+						clientV2: &mockV2PlatformClients{
+							iamClients: &iamv2test.MockClients{
+								GroupsServiceClient: iamv2test.MockGroupsServiceClient{
+									T:             t,
+									OnUpdateGroup: []test.On[*iamv2.UpdateGroupRequest, *iamv2.Group]{c.onUpdateGroup},
 								},
 							},
 						},
@@ -266,16 +288,19 @@ func TestGroupResource_updateResourceLimits(t *testing.T) {
 	r := &groupResource{
 		managedResource: managedResource{
 			prov: &providerData{
-				client: platformtest.MockPlatformClients{
-					IAMClient: iamtest.MockIAMClient{
-						GroupsClient: iamtest.MockGroupsClient{
-							OnUpdate: []iamtest.GroupOnUpdate{{
-								Given: &iam.Group{
-									Id:   "id",
-									Name: "name",
+				clientV2: &mockV2PlatformClients{
+					iamClients: &iamv2test.MockClients{
+						GroupsServiceClient: iamv2test.MockGroupsServiceClient{
+							T: t,
+							OnUpdateGroup: []test.On[*iamv2.UpdateGroupRequest, *iamv2.Group]{{
+								Given: &iamv2.UpdateGroupRequest{
+									Group: &iamv2.Group{
+										Uid:  "id",
+										Name: "name",
+									},
 								},
-								Updated: &iam.Group{
-									Id:             "id",
+								Result: &iamv2.Group{
+									Uid:            "id",
 									Name:           "name",
 									ResourceLimits: map[string]int32{"identities": 100},
 								},

--- a/internal/provider/resource_identity.go
+++ b/internal/provider/resource_identity.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/mapvalidator"
@@ -25,10 +26,11 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
-	"golang.org/x/exp/maps"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
-	iam "chainguard.dev/sdk/proto/platform/iam/v1"
+	iamv2 "chainguard.dev/sdk/proto/chainguard/platform/iam/v2beta1"
 	"chainguard.dev/sdk/uidp"
 	"chainguard.dev/sdk/validation"
 	"github.com/chainguard-dev/terraform-provider-chainguard/internal/validators"
@@ -102,7 +104,10 @@ func (r *identityResource) Metadata(_ context.Context, req resource.MetadataRequ
 
 // Schema defines the schema for the resource.
 func (r *identityResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
-	servicePrincipals := maps.Keys(iam.ServicePrincipal_value)
+	servicePrincipals := make([]string, 0, len(iamv2.ServicePrincipal_value))
+	for name := range iamv2.ServicePrincipal_value {
+		servicePrincipals = append(servicePrincipals, strings.TrimPrefix(name, "SERVICE_PRINCIPAL_"))
+	}
 
 	resp.Schema = schema.Schema{
 		Description: "IAM Identity in the Chainguard platform.",
@@ -349,7 +354,7 @@ func checkRFC3339(raw string) error {
 	return nil
 }
 
-func populateModel(ctx context.Context, model *identityResourceModel, id *iam.Identity) diag.Diagnostics {
+func populateModel(ctx context.Context, model *identityResourceModel, id *iamv2.Identity) diag.Diagnostics {
 	var allDiags diag.Diagnostics
 
 	if model == nil {
@@ -360,29 +365,29 @@ func populateModel(ctx context.Context, model *identityResourceModel, id *iam.Id
 	claimMatchTypes := model.ClaimMatch.AttributeTypes(ctx)
 	staticTypes := model.Static.AttributeTypes(ctx)
 
-	model.ID = types.StringValue(id.Id)
-	model.ParentID = types.StringValue(uidp.Parent(id.Id))
+	model.ID = types.StringValue(id.GetUid())
+	model.ParentID = types.StringValue(uidp.Parent(id.GetUid()))
 	model.Name = types.StringValue(id.Name)
 	if model.Description.IsNull() && id.Description != "" {
 		model.Description = types.StringValue(id.Description)
 	}
-	if id.CreatedAt != nil {
-		model.CreatedAt = types.StringValue(id.CreatedAt.AsTime().Format(time.RFC3339))
+	if id.CreateTime != nil {
+		model.CreatedAt = types.StringValue(id.CreateTime.AsTime().Format(time.RFC3339))
 	} else {
 		model.CreatedAt = types.StringNull()
 	}
-	if id.UpdatedAt != nil {
-		model.UpdatedAt = types.StringValue(id.UpdatedAt.AsTime().Format(time.RFC3339))
+	if id.UpdateTime != nil {
+		model.UpdatedAt = types.StringValue(id.UpdateTime.AsTime().Format(time.RFC3339))
 	} else {
 		model.UpdatedAt = types.StringNull()
 	}
-	if id.LastSeen != nil {
-		model.LastSeen = types.StringValue(id.LastSeen.AsTime().Format(time.RFC3339))
+	if id.LastSeenTime != nil {
+		model.LastSeen = types.StringValue(id.LastSeenTime.AsTime().Format(time.RFC3339))
 	} else {
 		model.LastSeen = types.StringNull()
 	}
 
-	if lit, ok := id.Relationship.(*iam.Identity_ClaimMatch_); ok {
+	if lit, ok := id.Relationship.(*iamv2.Identity_ClaimMatch_); ok {
 		var diags diag.Diagnostics
 
 		// Get the current state
@@ -424,27 +429,27 @@ func populateModel(ctx context.Context, model *identityResourceModel, id *iam.Id
 		}
 
 		switch lit.ClaimMatch.Iss.(type) {
-		case *iam.Identity_ClaimMatch_Issuer:
+		case *iamv2.Identity_ClaimMatch_Issuer:
 			cm.Issuer = types.StringValue(lit.ClaimMatch.GetIssuer())
-		case *iam.Identity_ClaimMatch_IssuerPattern:
+		case *iamv2.Identity_ClaimMatch_IssuerPattern:
 			cm.IssuerPattern = types.StringValue(lit.ClaimMatch.GetIssuerPattern())
 		default:
 			allDiags.AddError("failed to assign issuer", fmt.Sprintf("unsupported issuer type: %T", lit.ClaimMatch.Iss))
 		}
 
 		switch lit.ClaimMatch.Sub.(type) {
-		case *iam.Identity_ClaimMatch_Subject:
+		case *iamv2.Identity_ClaimMatch_Subject:
 			cm.Subject = types.StringValue(lit.ClaimMatch.GetSubject())
-		case *iam.Identity_ClaimMatch_SubjectPattern:
+		case *iamv2.Identity_ClaimMatch_SubjectPattern:
 			cm.SubjectPattern = types.StringValue(lit.ClaimMatch.GetSubjectPattern())
 		default:
 			allDiags.AddError("failed to assign subject", fmt.Sprintf("unsupported subject type: %T", lit.ClaimMatch.Sub))
 		}
 
 		switch lit.ClaimMatch.Aud.(type) {
-		case *iam.Identity_ClaimMatch_Audience:
+		case *iamv2.Identity_ClaimMatch_Audience:
 			cm.Audience = types.StringValue(lit.ClaimMatch.GetAudience())
-		case *iam.Identity_ClaimMatch_AudiencePattern:
+		case *iamv2.Identity_ClaimMatch_AudiencePattern:
 			cm.AudiencePattern = types.StringValue(lit.ClaimMatch.GetAudiencePattern())
 		default:
 			// This isn't a required field.
@@ -456,24 +461,24 @@ func populateModel(ctx context.Context, model *identityResourceModel, id *iam.Id
 		model.ClaimMatch = types.ObjectNull(claimMatchTypes)
 	}
 
-	if aws, ok := id.Relationship.(*iam.Identity_AwsIdentity); ok {
+	if aws, ok := id.Relationship.(*iamv2.Identity_AwsIdentity); ok {
 		awsModel := &awsIdentityModel{
 			Account: types.StringValue(aws.AwsIdentity.AwsAccount),
 		}
 
 		switch aws.AwsIdentity.AwsUserId.(type) {
-		case *iam.Identity_AWSIdentity_UserId:
+		case *iamv2.Identity_AWSIdentity_UserId:
 			awsModel.UserID = types.StringValue(aws.AwsIdentity.GetUserId())
-		case *iam.Identity_AWSIdentity_UserIdPattern:
+		case *iamv2.Identity_AWSIdentity_UserIdPattern:
 			awsModel.UserIDPattern = types.StringValue(aws.AwsIdentity.GetUserIdPattern())
 		default:
 			allDiags.AddError("failed to assign AWS user ID", fmt.Sprintf("unsupported user ID type: %T", aws.AwsIdentity.AwsUserId))
 		}
 
 		switch aws.AwsIdentity.AwsArn.(type) {
-		case *iam.Identity_AWSIdentity_Arn:
+		case *iamv2.Identity_AWSIdentity_Arn:
 			awsModel.ARN = types.StringValue(aws.AwsIdentity.GetArn())
-		case *iam.Identity_AWSIdentity_ArnPattern:
+		case *iamv2.Identity_AWSIdentity_ArnPattern:
 			awsModel.ARNPattern = types.StringValue(aws.AwsIdentity.GetArnPattern())
 		default:
 			allDiags.AddError("failed to assign AWS ARN", fmt.Sprintf("unsupported ARN type: %T", aws.AwsIdentity.AwsArn))
@@ -486,15 +491,15 @@ func populateModel(ctx context.Context, model *identityResourceModel, id *iam.Id
 		model.AWSIdentity = types.ObjectNull(awsTypes)
 	}
 
-	if st, ok := id.Relationship.(*iam.Identity_Static); ok {
+	if st, ok := id.Relationship.(*iamv2.Identity_StaticKeys_); ok {
 		expiration := types.StringNull()
-		if st.Static.Expiration != nil {
-			expiration = types.StringValue(st.Static.Expiration.AsTime().Format(time.RFC3339))
+		if st.StaticKeys.ExpirationTime != nil {
+			expiration = types.StringValue(st.StaticKeys.ExpirationTime.AsTime().Format(time.RFC3339))
 		}
 		static := &staticModel{
-			Issuer:     types.StringValue(st.Static.Issuer),
-			Subject:    types.StringValue(st.Static.Subject),
-			IssuerKeys: types.StringValue(st.Static.IssuerKeys),
+			Issuer:     types.StringValue(st.StaticKeys.Issuer),
+			Subject:    types.StringValue(st.StaticKeys.Subject),
+			IssuerKeys: types.StringValue(st.StaticKeys.IssuerKeys),
 			Expiration: expiration,
 		}
 
@@ -505,8 +510,8 @@ func populateModel(ctx context.Context, model *identityResourceModel, id *iam.Id
 		model.Static = types.ObjectNull(staticTypes)
 	}
 
-	if sp, ok := id.Relationship.(*iam.Identity_ServicePrincipal); ok {
-		v := iam.ServicePrincipal_name[int32(sp.ServicePrincipal)]
+	if sp, ok := id.Relationship.(*iamv2.Identity_ServicePrincipal); ok {
+		v := strings.TrimPrefix(iamv2.ServicePrincipal_name[int32(sp.ServicePrincipal)], "SERVICE_PRINCIPAL_")
 		model.ServicePrincipal = types.StringValue(v)
 	} else {
 		model.ServicePrincipal = types.StringNull()
@@ -515,9 +520,9 @@ func populateModel(ctx context.Context, model *identityResourceModel, id *iam.Id
 	return allDiags
 }
 
-func populateIdentity(ctx context.Context, m identityResourceModel) (*iam.Identity, error) {
-	id := &iam.Identity{
-		Id:          m.ID.ValueString(),
+func populateIdentity(ctx context.Context, m identityResourceModel) (*iamv2.Identity, error) {
+	id := &iamv2.Identity{
+		Uid:         m.ID.ValueString(),
 		Name:        m.Name.ValueString(),
 		Description: m.Description.ValueString(),
 	}
@@ -546,48 +551,48 @@ func populateIdentity(ctx context.Context, m identityResourceModel) (*iam.Identi
 			}
 		}
 
-		cm := &iam.Identity_ClaimMatch{
+		cm := &iamv2.Identity_ClaimMatch{
 			Claims:        claims,
 			ClaimPatterns: claimPatterns,
 		}
 
 		// Issuer or IssuerPattern; only one is not null due to validators
 		if !cmModel.Issuer.IsNull() {
-			cm.Iss = &iam.Identity_ClaimMatch_Issuer{
+			cm.Iss = &iamv2.Identity_ClaimMatch_Issuer{
 				Issuer: cmModel.Issuer.ValueString(),
 			}
 		}
 		if !cmModel.IssuerPattern.IsNull() {
-			cm.Iss = &iam.Identity_ClaimMatch_IssuerPattern{
+			cm.Iss = &iamv2.Identity_ClaimMatch_IssuerPattern{
 				IssuerPattern: cmModel.IssuerPattern.ValueString(),
 			}
 		}
 
 		// Subject or SubjectPattern; only one is not null due to validators
 		if !cmModel.Subject.IsNull() {
-			cm.Sub = &iam.Identity_ClaimMatch_Subject{
+			cm.Sub = &iamv2.Identity_ClaimMatch_Subject{
 				Subject: cmModel.Subject.ValueString(),
 			}
 		}
 		if !cmModel.SubjectPattern.IsNull() {
-			cm.Sub = &iam.Identity_ClaimMatch_SubjectPattern{
+			cm.Sub = &iamv2.Identity_ClaimMatch_SubjectPattern{
 				SubjectPattern: cmModel.SubjectPattern.ValueString(),
 			}
 		}
 
 		// Audience or AudiencePattern; at most one is not null due to validators (both may be null)
 		if !cmModel.Audience.IsNull() {
-			cm.Aud = &iam.Identity_ClaimMatch_Audience{
+			cm.Aud = &iamv2.Identity_ClaimMatch_Audience{
 				Audience: cmModel.Audience.ValueString(),
 			}
 		}
 		if !cmModel.AudiencePattern.IsNull() {
-			cm.Aud = &iam.Identity_ClaimMatch_AudiencePattern{
+			cm.Aud = &iamv2.Identity_ClaimMatch_AudiencePattern{
 				AudiencePattern: cmModel.AudiencePattern.ValueString(),
 			}
 		}
 
-		id.Relationship = &iam.Identity_ClaimMatch_{
+		id.Relationship = &iamv2.Identity_ClaimMatch_{
 			ClaimMatch: cm,
 		}
 	} else if !m.AWSIdentity.IsNull() {
@@ -597,35 +602,35 @@ func populateIdentity(ctx context.Context, m identityResourceModel) (*iam.Identi
 			return nil, errors.New("failed to cast aws model from state or plan")
 		}
 
-		aws := &iam.Identity_AWSIdentity{
+		aws := &iamv2.Identity_AWSIdentity{
 			AwsAccount: awsModel.Account.ValueString(),
 		}
 
 		// UserID or UserIDPattern; only one is not null due to validators
 		if !awsModel.UserID.IsNull() {
-			aws.AwsUserId = &iam.Identity_AWSIdentity_UserId{
+			aws.AwsUserId = &iamv2.Identity_AWSIdentity_UserId{
 				UserId: awsModel.UserID.ValueString(),
 			}
 		}
 		if !awsModel.UserIDPattern.IsNull() {
-			aws.AwsUserId = &iam.Identity_AWSIdentity_UserIdPattern{
+			aws.AwsUserId = &iamv2.Identity_AWSIdentity_UserIdPattern{
 				UserIdPattern: awsModel.UserIDPattern.ValueString(),
 			}
 		}
 
 		// ARN or ARNPattern; only one is not null due to validators
 		if !awsModel.ARN.IsNull() {
-			aws.AwsArn = &iam.Identity_AWSIdentity_Arn{
+			aws.AwsArn = &iamv2.Identity_AWSIdentity_Arn{
 				Arn: awsModel.ARN.ValueString(),
 			}
 		}
 		if !awsModel.ARNPattern.IsNull() {
-			aws.AwsArn = &iam.Identity_AWSIdentity_ArnPattern{
+			aws.AwsArn = &iamv2.Identity_AWSIdentity_ArnPattern{
 				ArnPattern: awsModel.ARNPattern.ValueString(),
 			}
 		}
 
-		id.Relationship = &iam.Identity_AwsIdentity{
+		id.Relationship = &iamv2.Identity_AwsIdentity{
 			AwsIdentity: aws,
 		}
 	} else if !m.Static.IsNull() {
@@ -643,17 +648,17 @@ func populateIdentity(ctx context.Context, m identityResourceModel) (*iam.Identi
 		}
 		exp = timestamppb.New(ts)
 
-		id.Relationship = &iam.Identity_Static{
-			Static: &iam.Identity_StaticKeys{
-				Issuer:     stModel.Issuer.ValueString(),
-				Subject:    stModel.Subject.ValueString(),
-				IssuerKeys: stModel.IssuerKeys.ValueString(),
-				Expiration: exp,
+		id.Relationship = &iamv2.Identity_StaticKeys_{
+			StaticKeys: &iamv2.Identity_StaticKeys{
+				Issuer:         stModel.Issuer.ValueString(),
+				Subject:        stModel.Subject.ValueString(),
+				IssuerKeys:     stModel.IssuerKeys.ValueString(),
+				ExpirationTime: exp,
 			},
 		}
 	} else if !m.ServicePrincipal.IsNull() {
-		id.Relationship = &iam.Identity_ServicePrincipal{
-			ServicePrincipal: iam.ServicePrincipal(iam.ServicePrincipal_value[m.ServicePrincipal.ValueString()]),
+		id.Relationship = &iamv2.Identity_ServicePrincipal{
+			ServicePrincipal: iamv2.ServicePrincipal(iamv2.ServicePrincipal_value["SERVICE_PRINCIPAL_"+m.ServicePrincipal.ValueString()]),
 		}
 	} else {
 		// This shouldn't happen with our validation.
@@ -686,9 +691,9 @@ func (r *identityResource) Create(ctx context.Context, req resource.CreateReques
 
 	// Create the identity. Retry on PermissionDenied to handle eventual
 	// consistency when the parent group was just created in the same apply.
-	ident, err := retryOnPermissionDenied(ctx, func() (*iam.Identity, error) {
-		return r.prov.client.IAM().Identities().Create(ctx, &iam.CreateIdentityRequest{
-			ParentId: plan.ParentID.ValueString(),
+	ident, err := retryOnPermissionDenied(ctx, func() (*iamv2.Identity, error) {
+		return r.prov.clientV2.IAM().IdentitiesService().CreateIdentity(ctx, &iamv2.CreateIdentityRequest{
+			Parent:   plan.ParentID.ValueString(),
 			Identity: identity,
 		})
 	})
@@ -717,26 +722,18 @@ func (r *identityResource) Read(ctx context.Context, req resource.ReadRequest, r
 
 	// Query for the identity to update state
 	identID := state.ID.ValueString()
-	identityList, err := r.prov.client.IAM().Identities().List(ctx, &iam.IdentityFilter{
-		Id: identID,
+	ident, err := r.prov.clientV2.IAM().IdentitiesService().GetIdentity(ctx, &iamv2.GetIdentityRequest{
+		Uid: identID,
 	})
 	if err != nil {
-		resp.Diagnostics.Append(errorToDiagnostic(err, "failed to list identities"))
+		if status.Code(err) == codes.NotFound {
+			// Identity doesn't exist or was deleted outside TF
+			resp.State.RemoveResource(ctx)
+			return
+		}
+		resp.Diagnostics.Append(errorToDiagnostic(err, "failed to get identity"))
 		return
 	}
-
-	switch c := len(identityList.GetItems()); {
-	case c == 0:
-		// Identity doesn't exist or was deleted outside TF
-		resp.State.RemoveResource(ctx)
-		return
-	case c > 1:
-		tflog.Error(ctx, fmt.Sprintf("identities list returned %d identities for id %q", c, identID))
-		resp.Diagnostics.AddError("internal error", fmt.Sprintf("fatal data corruption: id %s matched more than one identity", identID))
-		return
-	}
-
-	ident := identityList.GetItems()[0]
 
 	// If any errors were encountered, exit before updating the state.
 	if resp.Diagnostics.Append(populateModel(ctx, &state, ident)...); resp.Diagnostics.HasError() {
@@ -763,7 +760,9 @@ func (r *identityResource) Update(ctx context.Context, req resource.UpdateReques
 		return
 	}
 
-	updated, err := r.prov.client.IAM().Identities().Update(ctx, ident)
+	updated, err := r.prov.clientV2.IAM().IdentitiesService().UpdateIdentity(ctx, &iamv2.UpdateIdentityRequest{
+		Identity: ident,
+	})
 	if err != nil {
 		resp.Diagnostics.Append(errorToDiagnostic(err, fmt.Sprintf("failed to update identity %q", plan.ID.ValueString())))
 		return
@@ -789,8 +788,8 @@ func (r *identityResource) Delete(ctx context.Context, req resource.DeleteReques
 	tflog.Info(ctx, fmt.Sprintf("delete identity request: %s", state.ID))
 
 	id := state.ID.ValueString()
-	_, err := r.prov.client.IAM().Identities().Delete(ctx, &iam.DeleteIdentityRequest{
-		Id: id,
+	_, err := r.prov.clientV2.IAM().IdentitiesService().DeleteIdentity(ctx, &iamv2.DeleteIdentityRequest{
+		Uid: id,
 	})
 	if err != nil {
 		resp.Diagnostics.Append(errorToDiagnostic(err, fmt.Sprintf("failed to delete identity %q", id)))

--- a/internal/provider/resource_identity.go
+++ b/internal/provider/resource_identity.go
@@ -105,7 +105,10 @@ func (r *identityResource) Metadata(_ context.Context, req resource.MetadataRequ
 // Schema defines the schema for the resource.
 func (r *identityResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
 	servicePrincipals := make([]string, 0, len(iamv2.ServicePrincipal_value))
-	for name := range iamv2.ServicePrincipal_value {
+	for name, val := range iamv2.ServicePrincipal_value {
+		if val == 0 {
+			continue
+		}
 		servicePrincipals = append(servicePrincipals, strings.TrimPrefix(name, "SERVICE_PRINCIPAL_"))
 	}
 
@@ -792,6 +795,9 @@ func (r *identityResource) Delete(ctx context.Context, req resource.DeleteReques
 		Uid: id,
 	})
 	if err != nil {
+		if status.Code(err) == codes.NotFound {
+			return
+		}
 		resp.Diagnostics.Append(errorToDiagnostic(err, fmt.Sprintf("failed to delete identity %q", id)))
 		return
 	}

--- a/internal/provider/resource_identity_provider.go
+++ b/internal/provider/resource_identity_provider.go
@@ -21,7 +21,10 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
-	iam "chainguard.dev/sdk/proto/platform/iam/v1"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	iamv2 "chainguard.dev/sdk/proto/chainguard/platform/iam/v2beta1"
 	"chainguard.dev/sdk/uidp"
 	"github.com/chainguard-dev/terraform-provider-chainguard/internal/validators"
 )
@@ -149,9 +152,9 @@ func (r *identityProviderResource) ImportState(ctx context.Context, req resource
 	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
 }
 
-func populateIDP(ctx context.Context, model *identityProviderResourceModel) (*iam.IdentityProvider, error) {
-	idp := &iam.IdentityProvider{
-		Id:          model.ID.ValueString(),
+func populateIDPv2(ctx context.Context, model *identityProviderResourceModel) (*iamv2.IdentityProvider, error) {
+	idp := &iamv2.IdentityProvider{
+		Uid:         model.ID.ValueString(),
 		Name:        model.Name.ValueString(),
 		Description: model.Description.ValueString(),
 		DefaultRole: model.DefaultRole.ValueString(),
@@ -170,8 +173,8 @@ func populateIDP(ctx context.Context, model *identityProviderResourceModel) (*ia
 			return nil, errors.New("failed to cast additional_scopes from oidc model")
 		}
 
-		idp.Configuration = &iam.IdentityProvider_Oidc{
-			Oidc: &iam.IdentityProvider_OIDC{
+		idp.Configuration = &iamv2.IdentityProvider_Oidc{
+			Oidc: &iamv2.IdentityProvider_OIDC{
 				Issuer:           oidc.Issuer.ValueString(),
 				ClientId:         oidc.ClientID.ValueString(),
 				ClientSecret:     oidc.ClientSecret.ValueString(),
@@ -196,17 +199,17 @@ func (r *identityProviderResource) Create(ctx context.Context, req resource.Crea
 	}
 	tflog.Info(ctx, fmt.Sprintf("create identity provider: parent_id=%s, name=%s", plan.ParentID, plan.Name))
 
-	idp, err := populateIDP(ctx, &plan)
+	idp, err := populateIDPv2(ctx, &plan)
 	if err != nil {
-		resp.Diagnostics.Append(errorToDiagnostic(err, "failed to convert plan to IAM policy"))
+		resp.Diagnostics.Append(errorToDiagnostic(err, "failed to convert plan to identity provider"))
 		return
 	}
 
 	// Retry on PermissionDenied to handle eventual consistency when the
 	// parent group was just created in the same apply.
-	idp, err = retryOnPermissionDenied(ctx, func() (*iam.IdentityProvider, error) {
-		return r.prov.client.IAM().IdentityProviders().Create(ctx, &iam.CreateIdentityProviderRequest{
-			ParentId:         plan.ParentID.ValueString(),
+	idp, err = retryOnPermissionDenied(ctx, func() (*iamv2.IdentityProvider, error) {
+		return r.prov.clientV2.IAM().IdentityProvidersService().CreateIdentityProvider(ctx, &iamv2.CreateIdentityProviderRequest{
+			Parent:           plan.ParentID.ValueString(),
 			IdentityProvider: idp,
 		})
 	})
@@ -216,7 +219,7 @@ func (r *identityProviderResource) Create(ctx context.Context, req resource.Crea
 	}
 
 	// Save identity provider ID in the state.
-	plan.ID = types.StringValue(idp.Id)
+	plan.ID = types.StringValue(idp.GetUid())
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
 }
 
@@ -231,37 +234,30 @@ func (r *identityProviderResource) Read(ctx context.Context, req resource.ReadRe
 	tflog.Info(ctx, fmt.Sprintf("read identity provider request: %s", state.ID))
 
 	id := state.ID.ValueString()
-	idpList, err := r.prov.client.IAM().IdentityProviders().List(ctx, &iam.IdentityProviderFilter{
-		Id: id,
+	idp, err := r.prov.clientV2.IAM().IdentityProvidersService().GetIdentityProvider(ctx, &iamv2.GetIdentityProviderRequest{
+		Uid: id,
 	})
 	if err != nil {
-		resp.Diagnostics.Append(errorToDiagnostic(err, "failed to list identity providers"))
+		if status.Code(err) == codes.NotFound {
+			// IdP was deleted outside TF, remove from state
+			resp.State.RemoveResource(ctx)
+			return
+		}
+		resp.Diagnostics.Append(errorToDiagnostic(err, "failed to get identity provider"))
 		return
 	}
 
-	switch c := len(idpList.GetItems()); {
-	case c == 0:
-		// IdP was deleted outside TF, remove from state
-		resp.State.RemoveResource(ctx)
-		return
-	case c > 1:
-		tflog.Error(ctx, fmt.Sprintf("policy list returned %d policies for id %s", c, id))
-		resp.Diagnostics.AddError("failed to list policy", fmt.Sprintf("more than one policy found matching id %s", id))
-		return
+	state.ID = types.StringValue(idp.GetUid())
+	state.Name = types.StringValue(idp.GetName())
+	if !state.Description.IsNull() || idp.GetDescription() != "" {
+		state.Description = types.StringValue(idp.GetDescription())
 	}
-
-	idp := idpList.GetItems()[0]
-	state.ID = types.StringValue(idp.Id)
-	state.Name = types.StringValue(idp.Name)
-	if !state.Description.IsNull() || idp.Description != "" {
-		state.Description = types.StringValue(idp.Description)
-	}
-	state.DefaultRole = types.StringValue(idp.DefaultRole)
-	state.ParentID = types.StringValue(uidp.Parent(idp.Id))
+	state.DefaultRole = types.StringValue(idp.GetDefaultRole())
+	state.ParentID = types.StringValue(uidp.Parent(idp.GetUid()))
 
 	switch conf := idp.Configuration.(type) {
-	case *iam.IdentityProvider_Oidc:
-		scopes, diags := types.ListValueFrom(ctx, types.StringType, conf.Oidc.AdditionalScopes)
+	case *iamv2.IdentityProvider_Oidc:
+		scopes, diags := types.ListValueFrom(ctx, types.StringType, conf.Oidc.GetAdditionalScopes())
 		if diags.HasError() {
 			resp.Diagnostics.Append(diags...)
 			return
@@ -275,14 +271,14 @@ func (r *identityProviderResource) Read(ctx context.Context, req resource.ReadRe
 				return
 			}
 
-			update = (oidc.ClientID.ValueString() != conf.Oidc.ClientId) ||
-				(oidc.Issuer.ValueString() != conf.Oidc.Issuer) ||
+			update = (oidc.ClientID.ValueString() != conf.Oidc.GetClientId()) ||
+				(oidc.Issuer.ValueString() != conf.Oidc.GetIssuer()) ||
 				(!oidc.AdditionalScopes.Equal(scopes))
 		}
 		// Only update values if different to prevent Terraform reporting state drift
 		if update {
-			oidc.Issuer = types.StringValue(conf.Oidc.Issuer)
-			oidc.ClientID = types.StringValue(conf.Oidc.ClientId)
+			oidc.Issuer = types.StringValue(conf.Oidc.GetIssuer())
+			oidc.ClientID = types.StringValue(conf.Oidc.GetClientId())
 			// ClientSecret is not returned by the API
 			oidc.AdditionalScopes = scopes
 			state.OIDC, diags = types.ObjectValueFrom(ctx, state.OIDC.AttributeTypes(ctx), oidc)
@@ -311,13 +307,15 @@ func (r *identityProviderResource) Update(ctx context.Context, req resource.Upda
 	}
 	tflog.Info(ctx, fmt.Sprintf("update identity provider request: %s", data.ID))
 
-	idp, err := populateIDP(ctx, &data)
+	idp, err := populateIDPv2(ctx, &data)
 	if err != nil {
-		resp.Diagnostics.Append(errorToDiagnostic(err, "failed to convert plan to IAM policy"))
+		resp.Diagnostics.Append(errorToDiagnostic(err, "failed to convert plan to identity provider"))
 		return
 	}
 
-	if _, err := r.prov.client.IAM().IdentityProviders().Update(ctx, idp); err != nil {
+	if _, err := r.prov.clientV2.IAM().IdentityProvidersService().UpdateIdentityProvider(ctx, &iamv2.UpdateIdentityProviderRequest{
+		IdentityProvider: idp,
+	}); err != nil {
 		resp.Diagnostics.Append(errorToDiagnostic(err, "failed to update identity provider"))
 		return
 	}
@@ -336,8 +334,8 @@ func (r *identityProviderResource) Delete(ctx context.Context, req resource.Dele
 	tflog.Info(ctx, fmt.Sprintf("delete identity provider request: %s", state.ID))
 
 	id := state.ID.ValueString()
-	_, err := r.prov.client.IAM().IdentityProviders().Delete(ctx, &iam.DeleteIdentityProviderRequest{
-		Id: id,
+	_, err := r.prov.clientV2.IAM().IdentityProvidersService().DeleteIdentityProvider(ctx, &iamv2.DeleteIdentityProviderRequest{
+		Uid: id,
 	})
 	if err != nil {
 		resp.Diagnostics.Append(errorToDiagnostic(err, fmt.Sprintf("failed to delete identity provider %q", id)))

--- a/internal/provider/resource_identity_provider.go
+++ b/internal/provider/resource_identity_provider.go
@@ -338,6 +338,9 @@ func (r *identityProviderResource) Delete(ctx context.Context, req resource.Dele
 		Uid: id,
 	})
 	if err != nil {
+		if status.Code(err) == codes.NotFound {
+			return
+		}
 		resp.Diagnostics.Append(errorToDiagnostic(err, fmt.Sprintf("failed to delete identity provider %q", id)))
 	}
 }

--- a/internal/provider/resource_role.go
+++ b/internal/provider/resource_role.go
@@ -179,8 +179,13 @@ func (r *roleResource) Read(ctx context.Context, req resource.ReadRequest, resp 
 	state.Description = types.StringValue(role.GetDescription())
 	state.ParentID = types.StringValue(uidp.Parent(role.GetUid()))
 
+	capStrs, err := capabilityStrings(role.GetCapabilities())
+	if err != nil {
+		resp.Diagnostics.Append(errorToDiagnostic(err, "failed to stringify capabilities"))
+		return
+	}
 	var diags diag.Diagnostics
-	state.Capabilities, diags = types.SetValueFrom(ctx, types.StringType, capabilityStrings(role.GetCapabilities()))
+	state.Capabilities, diags = types.SetValueFrom(ctx, types.StringType, capStrs)
 	if diags.HasError() {
 		resp.Diagnostics.Append(diags...)
 		return
@@ -229,7 +234,12 @@ func (r *roleResource) Update(ctx context.Context, req resource.UpdateRequest, r
 	data.ID = types.StringValue(role.GetUid())
 	data.Name = types.StringValue(role.GetName())
 	data.Description = types.StringValue(role.GetDescription())
-	data.Capabilities, diags = types.SetValueFrom(ctx, types.StringType, capabilityStrings(role.GetCapabilities()))
+	capStrs, err := capabilityStrings(role.GetCapabilities())
+	if err != nil {
+		resp.Diagnostics.Append(errorToDiagnostic(err, "failed to stringify capabilities"))
+		return
+	}
+	data.Capabilities, diags = types.SetValueFrom(ctx, types.StringType, capStrs)
 	if diags.HasError() {
 		resp.Diagnostics.Append(diags...)
 		return

--- a/internal/provider/resource_role.go
+++ b/internal/provider/resource_role.go
@@ -252,6 +252,9 @@ func (r *roleResource) Delete(ctx context.Context, req resource.DeleteRequest, r
 		Uid: id,
 	})
 	if err != nil {
+		if status.Code(err) == codes.NotFound {
+			return
+		}
 		resp.Diagnostics.Append(errorToDiagnostic(err, fmt.Sprintf("failed to delete role %q", id)))
 		return
 	}

--- a/internal/provider/resource_role.go
+++ b/internal/provider/resource_role.go
@@ -20,7 +20,11 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
-	iam "chainguard.dev/sdk/proto/platform/iam/v1"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"chainguard.dev/sdk/proto/capabilities"
+	iamv2 "chainguard.dev/sdk/proto/chainguard/platform/iam/v2beta1"
 	"chainguard.dev/sdk/uidp"
 	"github.com/chainguard-dev/terraform-provider-chainguard/internal/validators"
 )
@@ -117,15 +121,21 @@ func (r *roleResource) Create(ctx context.Context, req resource.CreateRequest, r
 		return
 	}
 
+	parsedCaps, diags := parseCapabilities(ctx, caps)
+	if diags.HasError() {
+		resp.Diagnostics.Append(diags...)
+		return
+	}
+
 	// Retry on PermissionDenied to handle eventual consistency when the
 	// parent group was just created in the same apply.
-	role, err := retryOnPermissionDenied(ctx, func() (*iam.Role, error) {
-		return r.prov.client.IAM().Roles().Create(ctx, &iam.CreateRoleRequest{
-			ParentId: plan.ParentID.ValueString(),
-			Role: &iam.Role{
+	role, err := retryOnPermissionDenied(ctx, func() (*iamv2.Role, error) {
+		return r.prov.clientV2.IAM().RolesService().CreateRole(ctx, &iamv2.CreateRoleRequest{
+			Parent: plan.ParentID.ValueString(),
+			Role: &iamv2.Role{
 				Name:         plan.Name.ValueString(),
 				Description:  plan.Description.ValueString(),
-				Capabilities: caps,
+				Capabilities: parsedCaps,
 			},
 		})
 	})
@@ -135,7 +145,7 @@ func (r *roleResource) Create(ctx context.Context, req resource.CreateRequest, r
 	}
 
 	// Save role details in the state.
-	plan.ID = types.StringValue(role.Id)
+	plan.ID = types.StringValue(role.GetUid())
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
 }
 
@@ -149,42 +159,35 @@ func (r *roleResource) Read(ctx context.Context, req resource.ReadRequest, resp 
 	}
 	tflog.Info(ctx, fmt.Sprintf("read role request: %s", state.ID))
 
-	// Query for the role to update state
+	// Query for the role using GetRole instead of List-by-ID.
 	roleID := state.ID.ValueString()
-	roleList, err := r.prov.client.IAM().Roles().List(ctx, &iam.RoleFilter{
-		Id: roleID,
+	role, err := r.prov.clientV2.IAM().RolesService().GetRole(ctx, &iamv2.GetRoleRequest{
+		Uid: roleID,
 	})
 	if err != nil {
-		resp.Diagnostics.Append(errorToDiagnostic(err, "failed to list roles"))
+		if status.Code(err) == codes.NotFound {
+			// Role doesn't exist or was deleted outside TF
+			resp.State.RemoveResource(ctx)
+			return
+		}
+		resp.Diagnostics.Append(errorToDiagnostic(err, "failed to get role"))
 		return
 	}
 
-	switch c := len(roleList.GetItems()); c {
-	case 0:
-		// Role doesn't exist or was deleted outside TF
-		resp.State.RemoveResource(ctx)
+	state.ID = types.StringValue(role.GetUid())
+	state.Name = types.StringValue(role.GetName())
+	state.Description = types.StringValue(role.GetDescription())
+	state.ParentID = types.StringValue(uidp.Parent(role.GetUid()))
 
-	case 1:
-		r := roleList.GetItems()[0]
-		state.ID = types.StringValue(r.Id)
-		state.Name = types.StringValue(r.Name)
-		state.Description = types.StringValue(r.Description)
-		state.ParentID = types.StringValue(uidp.Parent(r.Id))
-
-		var diags diag.Diagnostics
-		state.Capabilities, diags = types.SetValueFrom(ctx, types.StringType, r.Capabilities)
-		if diags.HasError() {
-			resp.Diagnostics.Append(diags...)
-			return
-		}
-
-		// Set state
-		resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
-
-	default:
-		tflog.Error(ctx, fmt.Sprintf("role list returned %d roles for id %q", c, roleID))
-		resp.Diagnostics.AddError("internal error", fmt.Sprintf("fatal data corruption: id %s matched more than one role", roleID))
+	var diags diag.Diagnostics
+	state.Capabilities, diags = types.SetValueFrom(ctx, types.StringType, capabilityStrings(role.GetCapabilities()))
+	if diags.HasError() {
+		resp.Diagnostics.Append(diags...)
+		return
 	}
+
+	// Set state
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 }
 
 // Update updates the resource and sets the updated Terraform state on success.
@@ -203,11 +206,19 @@ func (r *roleResource) Update(ctx context.Context, req resource.UpdateRequest, r
 		return
 	}
 
-	role, err := r.prov.client.IAM().Roles().Update(ctx, &iam.Role{
-		Id:           data.ID.ValueString(),
-		Name:         data.Name.ValueString(),
-		Description:  data.Description.ValueString(),
-		Capabilities: caps,
+	parsedCaps, diags := parseCapabilities(ctx, caps)
+	if diags.HasError() {
+		resp.Diagnostics.Append(diags...)
+		return
+	}
+
+	role, err := r.prov.clientV2.IAM().RolesService().UpdateRole(ctx, &iamv2.UpdateRoleRequest{
+		Role: &iamv2.Role{
+			Uid:          data.ID.ValueString(),
+			Name:         data.Name.ValueString(),
+			Description:  data.Description.ValueString(),
+			Capabilities: parsedCaps,
+		},
 	})
 	if err != nil {
 		resp.Diagnostics.Append(errorToDiagnostic(err, fmt.Sprintf("failed to update role %q", data.ID.ValueString())))
@@ -215,11 +226,10 @@ func (r *roleResource) Update(ctx context.Context, req resource.UpdateRequest, r
 	}
 
 	// Set state
-	var diags diag.Diagnostics
-	data.ID = types.StringValue(role.Id)
+	data.ID = types.StringValue(role.GetUid())
 	data.Name = types.StringValue(role.GetName())
 	data.Description = types.StringValue(role.GetDescription())
-	data.Capabilities, diags = types.SetValueFrom(ctx, types.StringType, role.Capabilities)
+	data.Capabilities, diags = types.SetValueFrom(ctx, types.StringType, capabilityStrings(role.GetCapabilities()))
 	if diags.HasError() {
 		resp.Diagnostics.Append(diags...)
 		return
@@ -238,11 +248,26 @@ func (r *roleResource) Delete(ctx context.Context, req resource.DeleteRequest, r
 	tflog.Info(ctx, fmt.Sprintf("delete role request: %s", state.ID))
 
 	id := state.ID.ValueString()
-	_, err := r.prov.client.IAM().Roles().Delete(ctx, &iam.DeleteRoleRequest{
-		Id: id,
+	_, err := r.prov.clientV2.IAM().RolesService().DeleteRole(ctx, &iamv2.DeleteRoleRequest{
+		Uid: id,
 	})
 	if err != nil {
 		resp.Diagnostics.Append(errorToDiagnostic(err, fmt.Sprintf("failed to delete role %q", id)))
 		return
 	}
+}
+
+// parseCapabilities converts string capability names to the capabilities.Capability enum.
+func parseCapabilities(_ context.Context, caps []string) ([]capabilities.Capability, diag.Diagnostics) {
+	var diags diag.Diagnostics
+	result := make([]capabilities.Capability, 0, len(caps))
+	for _, c := range caps {
+		p, err := capabilities.Parse(c)
+		if err != nil {
+			diags.AddError("invalid capability", fmt.Sprintf("failed to parse capability %q: %v", c, err))
+			return nil, diags
+		}
+		result = append(result, p)
+	}
+	return result, diags
 }

--- a/internal/provider/resource_rolebinding.go
+++ b/internal/provider/resource_rolebinding.go
@@ -18,7 +18,10 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 
-	iam "chainguard.dev/sdk/proto/platform/iam/v1"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	iamv2 "chainguard.dev/sdk/proto/chainguard/platform/iam/v2beta1"
 	"github.com/chainguard-dev/terraform-provider-chainguard/internal/validators"
 )
 
@@ -102,12 +105,12 @@ func (r *rolebindingResource) Create(ctx context.Context, req resource.CreateReq
 
 	// Create the rolebinding. Retry on PermissionDenied to handle eventual
 	// consistency when the parent group was just created in the same apply.
-	binding, err := retryOnPermissionDenied(ctx, func() (*iam.RoleBinding, error) {
-		return r.prov.client.IAM().RoleBindings().Create(ctx, &iam.CreateRoleBindingRequest{
+	binding, err := retryOnPermissionDenied(ctx, func() (*iamv2.RoleBinding, error) {
+		return r.prov.clientV2.IAM().RoleBindingsService().CreateRoleBinding(ctx, &iamv2.CreateRoleBindingRequest{
 			Parent: plan.Group.ValueString(),
-			RoleBinding: &iam.RoleBinding{
-				Identity: plan.Identity.ValueString(),
-				Role:     plan.Role.ValueString(),
+			RoleBinding: &iamv2.RoleBinding{
+				IdentityUid: plan.Identity.ValueString(),
+				RoleUid:     plan.Role.ValueString(),
 			},
 		})
 	})
@@ -117,7 +120,7 @@ func (r *rolebindingResource) Create(ctx context.Context, req resource.CreateReq
 	}
 
 	// Save binding details in the state.
-	plan.ID = types.StringValue(binding.Id)
+	plan.ID = types.StringValue(binding.GetUid())
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
 }
 
@@ -131,35 +134,28 @@ func (r *rolebindingResource) Read(ctx context.Context, req resource.ReadRequest
 	}
 	tflog.Info(ctx, fmt.Sprintf("read rolebinding request: id=%s", state.ID))
 
-	// Query for the role to update state
+	// Query for the role binding using GetRoleBinding instead of List-by-ID.
 	rbID := state.ID.ValueString()
-	bindingList, err := r.prov.client.IAM().RoleBindings().List(ctx, &iam.RoleBindingFilter{
-		Id: rbID,
+	binding, err := r.prov.clientV2.IAM().RoleBindingsService().GetRoleBinding(ctx, &iamv2.GetRoleBindingRequest{
+		Uid: rbID,
 	})
 	if err != nil {
-		resp.Diagnostics.Append(errorToDiagnostic(err, "failed to list rolebindings"))
+		if status.Code(err) == codes.NotFound {
+			// Role binding doesn't exist or was deleted outside TF
+			resp.State.RemoveResource(ctx)
+			return
+		}
+		resp.Diagnostics.Append(errorToDiagnostic(err, "failed to get rolebinding"))
 		return
 	}
 
-	switch c := len(bindingList.GetItems()); c {
-	case 0:
-		// Role doesn't exist or was deleted outside TF
-		resp.State.RemoveResource(ctx)
+	state.ID = types.StringValue(binding.GetUid())
+	state.Group = types.StringValue(binding.GetGroup().GetUid())
+	state.Identity = types.StringValue(binding.GetIdentity().GetUid())
+	state.Role = types.StringValue(binding.GetRole().GetUid())
 
-	case 1:
-		binding := bindingList.GetItems()[0]
-		state.ID = types.StringValue(binding.Id)
-		state.Group = types.StringValue(binding.Group.Id)
-		state.Identity = types.StringValue(binding.Identity)
-		state.Role = types.StringValue(binding.Role.Id)
-
-		// Set state
-		resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
-
-	default:
-		tflog.Error(ctx, fmt.Sprintf("rolebinding list returned %d bindings for id %q", c, rbID))
-		resp.Diagnostics.AddError("internal error", fmt.Sprintf("fatal data corruption: id %s matched more than one rolebinding", rbID))
-	}
+	// Set state
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 }
 
 // Update updates the resource and sets the updated Terraform state on success.
@@ -172,10 +168,12 @@ func (r *rolebindingResource) Update(ctx context.Context, req resource.UpdateReq
 	}
 	tflog.Info(ctx, fmt.Sprintf("update rolebinding request: id=%s", data.ID))
 
-	binding, err := r.prov.client.IAM().RoleBindings().Update(ctx, &iam.RoleBinding{
-		Id:       data.ID.ValueString(),
-		Identity: data.Identity.ValueString(),
-		Role:     data.Role.ValueString(),
+	binding, err := r.prov.clientV2.IAM().RoleBindingsService().UpdateRoleBinding(ctx, &iamv2.UpdateRoleBindingRequest{
+		RoleBinding: &iamv2.RoleBinding{
+			Uid:         data.ID.ValueString(),
+			IdentityUid: data.Identity.ValueString(),
+			RoleUid:     data.Role.ValueString(),
+		},
 	})
 	if err != nil {
 		resp.Diagnostics.Append(errorToDiagnostic(err, fmt.Sprintf("failed to update rolebinding %q", data.ID.ValueString())))
@@ -183,9 +181,9 @@ func (r *rolebindingResource) Update(ctx context.Context, req resource.UpdateReq
 	}
 
 	// Set state
-	data.ID = types.StringValue(binding.Id)
-	data.Identity = types.StringValue(binding.Identity)
-	data.Role = types.StringValue(binding.Role)
+	data.ID = types.StringValue(binding.GetUid())
+	data.Identity = types.StringValue(binding.GetIdentityUid())
+	data.Role = types.StringValue(binding.GetRoleUid())
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
 
@@ -200,8 +198,8 @@ func (r *rolebindingResource) Delete(ctx context.Context, req resource.DeleteReq
 	tflog.Info(ctx, fmt.Sprintf("delete rolebinding request: id=%s", state.ID))
 
 	id := state.ID.ValueString()
-	_, err := r.prov.client.IAM().RoleBindings().Delete(ctx, &iam.DeleteRoleBindingRequest{
-		Id: id,
+	_, err := r.prov.clientV2.IAM().RoleBindingsService().DeleteRoleBinding(ctx, &iamv2.DeleteRoleBindingRequest{
+		Uid: id,
 	})
 	if err != nil {
 		resp.Diagnostics.Append(errorToDiagnostic(err, fmt.Sprintf("failed to delete rolebinding %q", id)))

--- a/internal/provider/resource_rolebinding.go
+++ b/internal/provider/resource_rolebinding.go
@@ -153,8 +153,16 @@ func (r *rolebindingResource) Read(ctx context.Context, req resource.ReadRequest
 	if g := binding.GetGroup(); g != nil {
 		state.Group = types.StringValue(g.GetUid())
 	}
-	state.Identity = types.StringValue(binding.GetIdentityUid())
-	state.Role = types.StringValue(binding.GetRoleUid())
+	if uid := binding.GetIdentityUid(); uid != "" {
+		state.Identity = types.StringValue(uid)
+	} else if id := binding.GetIdentity(); id != nil {
+		state.Identity = types.StringValue(id.GetUid())
+	}
+	if uid := binding.GetRoleUid(); uid != "" {
+		state.Role = types.StringValue(uid)
+	} else if r := binding.GetRole(); r != nil {
+		state.Role = types.StringValue(r.GetUid())
+	}
 
 	// Set state
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)

--- a/internal/provider/resource_rolebinding.go
+++ b/internal/provider/resource_rolebinding.go
@@ -192,8 +192,16 @@ func (r *rolebindingResource) Update(ctx context.Context, req resource.UpdateReq
 
 	// Set state
 	data.ID = types.StringValue(binding.GetUid())
-	data.Identity = types.StringValue(binding.GetIdentityUid())
-	data.Role = types.StringValue(binding.GetRoleUid())
+	if uid := binding.GetIdentityUid(); uid != "" {
+		data.Identity = types.StringValue(uid)
+	} else if id := binding.GetIdentity(); id != nil {
+		data.Identity = types.StringValue(id.GetUid())
+	}
+	if uid := binding.GetRoleUid(); uid != "" {
+		data.Role = types.StringValue(uid)
+	} else if r := binding.GetRole(); r != nil {
+		data.Role = types.StringValue(r.GetUid())
+	}
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
 

--- a/internal/provider/resource_rolebinding.go
+++ b/internal/provider/resource_rolebinding.go
@@ -150,9 +150,11 @@ func (r *rolebindingResource) Read(ctx context.Context, req resource.ReadRequest
 	}
 
 	state.ID = types.StringValue(binding.GetUid())
-	state.Group = types.StringValue(binding.GetGroup().GetUid())
-	state.Identity = types.StringValue(binding.GetIdentity().GetUid())
-	state.Role = types.StringValue(binding.GetRole().GetUid())
+	if g := binding.GetGroup(); g != nil {
+		state.Group = types.StringValue(g.GetUid())
+	}
+	state.Identity = types.StringValue(binding.GetIdentityUid())
+	state.Role = types.StringValue(binding.GetRoleUid())
 
 	// Set state
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
@@ -202,6 +204,9 @@ func (r *rolebindingResource) Delete(ctx context.Context, req resource.DeleteReq
 		Uid: id,
 	})
 	if err != nil {
+		if status.Code(err) == codes.NotFound {
+			return
+		}
 		resp.Diagnostics.Append(errorToDiagnostic(err, fmt.Sprintf("failed to delete rolebinding %q", id)))
 		return
 	}


### PR DESCRIPTION
## What

Migrate all 7 IAM Terraform resources from v1 to v2beta1 SDK clients, completing Step 2 of CUS-320.

Each resource swaps v1 client calls for v2beta1 equivalents:
- `r.prov.client.IAM().Groups().Create()` → `r.prov.clientV2.IAM().GroupsService().CreateGroup()`
- Read methods use dedicated Get RPCs instead of List-by-ID, with `codes.NotFound` handling
- Proto types updated: `iam.Role` → `iamv2.Role`, `Id` → `Uid`, `CreatedAt` → `CreateTime`, etc.

## Why

Dogfood the v2beta1 SDK ahead of GA. Same mixed-version approach as chainctl — v2beta1 for IAM, v1 for registry resources until Containers finishes CRUD.

## Resources migrated

- `resource_role` — 4 CRUD calls
- `resource_rolebinding` — 4 CRUD calls + retry
- `resource_group_invite` — 3 CRD calls (no Update)
- `resource_group` — 5 calls + import helper
- `resource_identity_provider` — 4 CRUD calls + OIDC/SAML config
- `resource_account_associations` — 4 CRUD calls + multi-provider model (AWS/GCP/Azure/GitHub)
- `resource_identity` — 4 CRUD calls + 4 relationship types (ClaimMatch, AWSIdentity, StaticKeys, ServicePrincipal)

## Proto field mapping

These are the v1 → v2beta1 renames applied throughout. All are mechanical:

| v1 | v2beta1 | Notes |
|---|---|---|
| `Id` / `GetId()` | `Uid` / `GetUid()` | Resource identifier |
| `ParentId` | `Parent` | On Create requests only |
| `CreatedAt` | `CreateTime` | Timestamp field |
| `UpdatedAt` | `UpdateTime` | Timestamp field |
| `LastSeen` | `LastSeenTime` | Identity only |
| `Identity_Static` | `Identity_StaticKeys_` | Oneof wrapper type renamed |
| `.Static` | `.StaticKeys` | Field on the wrapper |
| `.Expiration` | `.ExpirationTime` | StaticKeys field |
| `AccountAssociations` | `AccountAssociation` | Singular in v2beta1 |
| `.Group` (on AccountAssoc) | `.Uid` | Account association UID IS the group UIDP (1:1 relationship) |
| `ServicePrincipal` enum values | Prefixed with `SERVICE_PRINCIPAL_` | User-facing values preserved via `TrimPrefix`/prepend |

## Design decisions

**RoleBinding Read/Update accessor pattern**: The v2beta1 `RoleBinding` proto has both flat UID fields (`IdentityUid`, `RoleUid`) and hydrated objects (`Identity`, `Role`). Read and Update both prefer the flat getters and fall back to hydrated objects if empty. For `Group`, there is no flat `GroupUid` field in the proto — only a nested `Group *RoleBindingGroup` — so a nil check is used instead.

**Account associations Uid == Group UIDP**: The v2beta1 `AccountAssociation.Uid` field IS the parent group UIDP (documented in the proto: "Unique identifier (the group UIDP this association belongs to)"). This is because account associations are 1:1 per group. The code uses `state.ID` consistently for Delete/Get operations.

**`setClients` token refresh**: After root org creation, `waitForRoleBindingPropagation` force-refreshes the token (writes to disk cache). `setClients` then calls `token.Get(ctx, ..., false)` which reads the freshly-cached token — no second force-refresh needed.

**`waitForRoleBindingPropagation` stays on v1**: This helper creates fresh `platform.Clients` via `newPlatformClients`, which only constructs v1 clients. It's a transient retry mechanism for org creation, not a core CRUD path. Documented in code comment.

## Additional fixes (found during review)

- **`setClients` v2 refresh** — after root org creation, both v1 and v2beta1 clients are now refreshed with the new token scope; network I/O runs outside the mutex; old `clientV2` connection is closed before replacement
- **Capabilities stringify** — `capabilityStrings` now uses `capabilities.StringifyAll` to return human-readable names (`groups.list`) instead of raw proto enum names (`CAP_IAM_GROUPS_LIST`), with error propagation as diagnostics
- **ServicePrincipal enum mapping** — v2beta1 uses `SERVICE_PRINCIPAL_` prefix; user-facing Terraform values (`INGESTER`, `COSIGNED`) are preserved with prefix stripping/re-adding, and `UNSPECIFIED` (value 0) is filtered from the schema
- **NotFound in Delete** — all 7 resources handle `codes.NotFound` gracefully so `terraform destroy` succeeds when resources are already gone
- **RoleBinding Read/Update safety** — uses flat getters (`GetIdentityUid`, `GetRoleUid`) with fallback to hydrated objects in both Read and Update; nil check on `GetGroup()`
- **Account associations Delete** — uses `state.ID` instead of `state.Group` for consistency with other resources
- **Group unit tests** — migrated from v1 mocks to v2beta1 `iamv2test.MockGroupsServiceClient`

## What stays on v1 (intentional)

These are **not** in scope for this PR:

- `resource_image_repo` — blocked on Containers v2 CreateRepo/UpdateRepo
- `resource_image_tag` — no v2 equivalent yet
- `resource_deployment` — no v2 equivalent yet
- `resource_apko_build` — no v2 equivalent yet
- `resource_subscription` — deferred
- `checkDestroy` acceptance test helpers — v1 verification still works; migrating requires test infrastructure changes (separate effort)
- `data_source_identity.go` — uses v1 `LookupRequest` (already migrated in prior PR #520, except Lookup)

## Testing

- Full CRUD lifecycle validated against `sjohnson.guardenv.dev` dev environment:
  - **Create** 7 resources (group, role, 3 identity types incl. static/claim_match with patterns/service_principal, rolebinding, account_associations with AWS/GCP/Azure)
  - **Plan after Create**: no drift
  - **Update** role (name, description, capabilities), identity (claim_patterns), account_associations (all 3 providers)
  - **Plan after Update**: no drift
  - **Destroy** all 7 resources
- **Upgrade path validated**: state created by v1 provider binary → swapped to v2beta1 provider binary → `terraform plan` shows **no changes** (zero drift on upgrade)
- Unit tests: `TestGroupResource_update` (7 subtests) and `TestGroupResource_updateResourceLimits` pass with v2beta1 mocks
- `go build ./...` clean
- `golangci-lint run ./...` — 0 issues

Closes CUS-320 (Step 2)