### PR TITLE
fix(token): re-assume the session identity on token refresh

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -53,7 +53,7 @@ Optional:
 - `auth0_connection` (String) Auth0 social connection to use by default for OIDC token. Must be one of: google-oauth2, gitlab, github
 - `disabled` (Boolean) Disable automatic login when Chainguard token is expired.
 - `enable_refresh_tokens` (Boolean) Enable to use of refresh tokens when authenticating with an IdP (not compatible with identity_token authentication).
-- `identity_id` (String) UIDP of the identity to assume when exchanging OIDC token for Chainguard token.
+- `identity_id` (String) UIDP of the identity to assume when exchanging an OIDC token. Optional: when unset, token refreshes reuse the identity the current session was minted for; set it to pin a specific identity, or to separate token caches when multiple identities share an environment.
 - `identity_provider_id` (String) UIDP of the identity provider authenticate with for OIDC token.
 - `identity_token` (String, Sensitive) A path to an OIDC identity token, or explicit identity token.
 - `organization_name` (String) Verified organization name for determining identity provider to obtain OIDC token.

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -194,7 +194,7 @@ only consider the filtered versions.`,
 						Optional:    true,
 					},
 					"identity_id": schema.StringAttribute{
-						Description: "UIDP of the identity to assume when exchanging OIDC token for Chainguard token.",
+						Description: "UIDP of the identity to assume when exchanging an OIDC token. Optional: when unset, token refreshes reuse the identity the current session was minted for; set it to pin a specific identity, or to separate token caches when multiple identities share an environment.",
 						Optional:    true,
 						Validators:  []validator.String{validators.UIDP(false /* allowRootSentinel */)},
 					},

--- a/internal/token/token.go
+++ b/internal/token/token.go
@@ -18,6 +18,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
+	"chainguard.dev/sdk/auth"
 	"chainguard.dev/sdk/auth/login"
 	sdktoken "chainguard.dev/sdk/auth/token"
 	"chainguard.dev/sdk/sts"
@@ -107,7 +108,7 @@ func refreshChainguardToken(ctx context.Context, cfg LoginConfig, forceRefresh b
 	}
 
 	if cfg.IdentityToken != "" {
-		accessToken, err = exchangeToken(ctx, identityTokenForExchange(ctx, cfg), cfg)
+		accessToken, err = exchangeAmbient(ctx, cfg)
 	} else {
 		accessToken, refreshToken, err = getChainguardToken(ctx, cfg)
 	}
@@ -199,14 +200,27 @@ func identityTokenForExchange(ctx context.Context, cfg LoginConfig) string {
 	return tok
 }
 
-// exchangeToken gets a Chainguard token by exchanging the given OIDC token or path to a token.
-// No user interaction is required. Refresh tokens are not supported in this login flow.
-func exchangeToken(ctx context.Context, idToken string, cfg LoginConfig) (string, error) {
+// stsExchange runs the STS exchange targeting identityID ("" means untargeted).
+// A package var so tests can substitute it without a live issuer.
+var stsExchange = func(ctx context.Context, cfg LoginConfig, idToken, identityID string) (string, error) {
+	opts := []sts.ExchangerOption{
+		sts.WithUserAgent(cfg.UserAgent),
+		sts.WithIdentity(identityID),
+	}
+	tok, err := sts.ExchangePair(ctx, cfg.Issuer, cfg.Audience, idToken, opts...)
+	if err != nil {
+		return "", err
+	}
+	return tok.AccessToken, nil
+}
+
+// exchangeToken exchanges the given OIDC token (or path to one) for a Chainguard
+// token, targeting identityID ("" means an untargeted exchange).
+func exchangeToken(ctx context.Context, idToken string, cfg LoginConfig, identityID string) (string, error) {
 	tflog.Info(ctx, "exchanging oidc token for chainguard token")
 
-	// Test to see if identity token is a path or not.
+	// If idToken is a path rather than a token, read the token from that file.
 	if _, err := os.Stat(idToken); err == nil {
-		// Token was specified, and it is a path. Read the token in from that file.
 		b, err := os.ReadFile(idToken)
 		if err != nil {
 			return "", err
@@ -214,16 +228,37 @@ func exchangeToken(ctx context.Context, idToken string, cfg LoginConfig) (string
 		idToken = string(b)
 	}
 
-	opts := []sts.ExchangerOption{
-		sts.WithUserAgent(cfg.UserAgent),
-		// If IdentityID is empty this is a noop during exchange.
-		sts.WithIdentity(cfg.IdentityID),
-	}
+	return stsExchange(ctx, cfg, idToken, identityID)
+}
 
-	tok, err := sts.ExchangePair(ctx, cfg.Issuer, cfg.Audience, idToken, opts...)
+// effectiveExchangeIdentity returns the identity to target on refresh: the pin if
+// set, else the current token's sub (the identity it was minted for), else "".
+func effectiveExchangeIdentity(ctx context.Context, cfg LoginConfig) string {
+	if cfg.IdentityID != "" {
+		return cfg.IdentityID
+	}
+	raw, err := sdktoken.Load(sdktoken.KindAccess, cfg.Audience, withAlias(cfg))
 	if err != nil {
-		return "", err
+		// No current token to inherit an identity from; stay untargeted.
+		return ""
 	}
+	_, sub, err := auth.ExtractIssuerAndSubject(string(raw))
+	if err != nil {
+		tflog.Warn(ctx, fmt.Sprintf("cannot read identity from current token; using untargeted exchange: %v", err))
+		return ""
+	}
+	return sub
+}
 
-	return tok.AccessToken, nil
+// exchangeAmbient exchanges the OIDC token targeting the session's current identity.
+// If that identity was derived (not pinned) and the exchange fails, it retries untargeted.
+func exchangeAmbient(ctx context.Context, cfg LoginConfig) (string, error) {
+	idToken := identityTokenForExchange(ctx, cfg)
+	target := effectiveExchangeIdentity(ctx, cfg)
+	tok, err := exchangeToken(ctx, idToken, cfg, target)
+	if err != nil && target != "" && cfg.IdentityID == "" {
+		tflog.Warn(ctx, fmt.Sprintf("targeted exchange for derived identity failed; retrying untargeted: %v", err))
+		return exchangeToken(ctx, idToken, cfg, "")
+	}
+	return tok, err
 }

--- a/internal/token/token.go
+++ b/internal/token/token.go
@@ -22,6 +22,7 @@ import (
 	"chainguard.dev/sdk/auth/login"
 	sdktoken "chainguard.dev/sdk/auth/token"
 	"chainguard.dev/sdk/sts"
+	"chainguard.dev/sdk/uidp"
 )
 
 const (
@@ -245,6 +246,11 @@ func effectiveExchangeIdentity(ctx context.Context, cfg LoginConfig) string {
 	_, sub, err := auth.ExtractIssuerAndSubject(string(raw))
 	if err != nil {
 		tflog.Warn(ctx, fmt.Sprintf("cannot read identity from current token; using untargeted exchange: %v", err))
+		return ""
+	}
+	// Only target a well-formed UIDP; reuse the same check the schema validator applies to a pinned identity_id.
+	if !uidp.Valid(sub) {
+		tflog.Warn(ctx, fmt.Sprintf("current token sub %q is not a valid UIDP; using untargeted exchange", sub))
 		return ""
 	}
 	return sub

--- a/internal/token/token.go
+++ b/internal/token/token.go
@@ -202,7 +202,8 @@ func identityTokenForExchange(ctx context.Context, cfg LoginConfig) string {
 }
 
 // stsExchange runs the STS exchange targeting identityID ("" means untargeted).
-// A package var so tests can substitute it without a live issuer.
+// A package var so tests can substitute it without a live issuer; tests that
+// swap it must not run in parallel (it is process-global mutable state).
 var stsExchange = func(ctx context.Context, cfg LoginConfig, idToken, identityID string) (string, error) {
 	opts := []sts.ExchangerOption{
 		sts.WithUserAgent(cfg.UserAgent),

--- a/internal/token/token_test.go
+++ b/internal/token/token_test.go
@@ -8,13 +8,21 @@ package token
 import (
 	"context"
 	"encoding/base64"
+	"encoding/json"
 	"errors"
 	"fmt"
+	"os"
 	"slices"
+	"strings"
 	"testing"
+	"time"
 
+	"chainguard.dev/sdk/auth"
 	sdktoken "chainguard.dev/sdk/auth/token"
 	"github.com/sigstore/cosign/v2/pkg/providers"
+	// Registers the github-actions ambient provider so providers.Enabled works
+	// in this package's acc test binary (see TestExchangeAmbientRefreshTargetsSessionIdentity).
+	_ "github.com/sigstore/cosign/v2/pkg/providers/github"
 )
 
 // fakeAccessToken builds an unsigned JWT with the given sub claim.
@@ -200,5 +208,95 @@ func TestExchangeAmbient(t *testing.T) {
 				t.Errorf("calls=%v, want %v", calls, tc.wantCalls)
 			}
 		})
+	}
+}
+
+// TestExchangeAmbientRefreshTargetsSessionIdentity is an acceptance-gated
+// integration test against a live issuer: with NO identity pinned, a forced
+// refresh must re-assume the identity the current session already holds. This
+// is what lets callers drop a hardcoded identity_id and still refresh in an
+// environment where a repo maps to multiple identities.
+func TestExchangeAmbientRefreshTargetsSessionIdentity(t *testing.T) {
+	for _, v := range []string{"TF_ACC", "TF_ACC_AMBIENT", "TF_ACC_AUDIENCE", "TF_ACC_ISSUER"} {
+		if os.Getenv(v) == "" {
+			t.Skipf("%s not set; skipping ambient-refresh integration test", v)
+		}
+	}
+	ctx := context.Background()
+	// No IdentityID: this is the pin-free path under test.
+	cfg := LoginConfig{
+		Audience:  os.Getenv("TF_ACC_AUDIENCE"),
+		Issuer:    os.Getenv("TF_ACC_ISSUER"),
+		UserAgent: "terraform-provider-chainguard/acctest-refresh",
+	}
+
+	// Learn the session identity from the token setup-chainctl already cached.
+	if _, err := Get(ctx, cfg, false); err != nil {
+		t.Fatalf("initial token.Get: %v", err)
+	}
+	raw, err := sdktoken.Load(sdktoken.KindAccess, cfg.Audience, withAlias(cfg))
+	if err != nil {
+		t.Fatalf("load cached token: %v", err)
+	}
+	_, sessionID, err := auth.ExtractIssuerAndSubject(string(raw))
+	if err != nil || sessionID == "" {
+		t.Fatalf("read session identity: err=%v sub=%q", err, sessionID)
+	}
+
+	// Route the next refresh through the ambient OIDC exchange (as Configure would).
+	idToken, err := ResolveIdentityToken(ctx, cfg.Issuer, "")
+	if err != nil || idToken == "" {
+		t.Skipf("no ambient OIDC token available: err=%v", err)
+	}
+	cfg.IdentityToken = idToken
+
+	// Make the cached token look expired so the next Get refreshes now.
+	expireCachedAccessToken(t, cfg)
+
+	// Record the identity each refresh exchange targets (delegate to the real one).
+	var calls []string
+	orig := stsExchange
+	t.Cleanup(func() { stsExchange = orig })
+	stsExchange = func(c context.Context, lc LoginConfig, idt, identityID string) (string, error) {
+		calls = append(calls, identityID)
+		return orig(c, lc, idt, identityID)
+	}
+
+	if _, err := Get(ctx, cfg, false); err != nil {
+		t.Fatalf("forced refresh token.Get: %v", err)
+	}
+	if len(calls) == 0 || calls[0] != sessionID {
+		t.Fatalf("refresh targeted %v, want session identity %q first (unpinned refresh must re-assume the session identity)", calls, sessionID)
+	}
+}
+
+// expireCachedAccessToken rewrites the cached access token's exp claim to the
+// past, preserving the rest of the payload, so the provider treats it as expired.
+func expireCachedAccessToken(t *testing.T, cfg LoginConfig) {
+	t.Helper()
+	raw, err := sdktoken.Load(sdktoken.KindAccess, cfg.Audience, withAlias(cfg))
+	if err != nil {
+		t.Fatalf("load token to expire: %v", err)
+	}
+	parts := strings.Split(string(raw), ".")
+	if len(parts) < 2 {
+		t.Fatalf("cached token is not a JWT")
+	}
+	payload, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		t.Fatalf("decode token payload: %v", err)
+	}
+	var claims map[string]any
+	if err := json.Unmarshal(payload, &claims); err != nil {
+		t.Fatalf("unmarshal claims: %v", err)
+	}
+	claims["exp"] = time.Now().Add(-time.Hour).Unix()
+	nb, err := json.Marshal(claims)
+	if err != nil {
+		t.Fatalf("marshal claims: %v", err)
+	}
+	parts[1] = base64.RawURLEncoding.EncodeToString(nb)
+	if err := sdktoken.Save([]byte(strings.Join(parts, ".")), sdktoken.KindAccess, cfg.Audience, withAlias(cfg)); err != nil {
+		t.Fatalf("save expired token: %v", err)
 	}
 }

--- a/internal/token/token_test.go
+++ b/internal/token/token_test.go
@@ -25,6 +25,14 @@ import (
 	_ "github.com/sigstore/cosign/v2/pkg/providers/github"
 )
 
+// Valid UIDP-shaped identities for tests (40-hex group + 16-hex identity),
+// matching what the issuer sets as a real token's sub.
+const (
+	uidpDerived = "1111111111111111111111111111111111111111/1111111111111111"
+	uidpOther   = "2222222222222222222222222222222222222222/2222222222222222"
+	uidpPin     = "3333333333333333333333333333333333333333/3333333333333333"
+)
+
 // fakeAccessToken builds an unsigned JWT with the given sub claim.
 func fakeAccessToken(sub string) string {
 	payload := base64.RawURLEncoding.EncodeToString(fmt.Appendf(nil, `{"sub":%q}`, sub))
@@ -124,11 +132,12 @@ func TestEffectiveExchangeIdentity(t *testing.T) {
 		saveRaw    string // token to write to the cache ("" => none)
 		want       string
 	}{
-		"pin wins without reading cache":   {identityID: "group/pin", saveRaw: fakeAccessToken("group/other"), want: "group/pin"},
-		"derive from current token sub":    {saveRaw: fakeAccessToken("group/derived"), want: "group/derived"},
+		"pin wins without reading cache":   {identityID: uidpPin, saveRaw: fakeAccessToken(uidpOther), want: uidpPin},
+		"derive from current token sub":    {saveRaw: fakeAccessToken(uidpDerived), want: uidpDerived},
 		"no token stays untargeted":        {want: ""},
 		"malformed token stays untargeted": {saveRaw: "not-a-jwt", want: ""},
 		"empty sub stays untargeted":       {saveRaw: fakeAccessToken(""), want: ""},
+		"non-UIDP sub stays untargeted":    {saveRaw: fakeAccessToken("group/derived"), want: ""},
 	}
 
 	for name, tc := range tests {
@@ -168,9 +177,9 @@ func TestExchangeAmbient(t *testing.T) {
 		wantTok    string
 		wantErr    bool
 	}{
-		"derived identity succeeds":          {saveSub: "group/derived", wantCalls: []string{"group/derived"}, wantTok: "ok"},
-		"derived failure retries untargeted": {saveSub: "group/derived", failOn: []string{"group/derived"}, wantCalls: []string{"group/derived", ""}, wantTok: "ok"},
-		"pin failure does not fall back":     {identityID: "group/pin", failOn: []string{"group/pin"}, wantCalls: []string{"group/pin"}, wantErr: true},
+		"derived identity succeeds":          {saveSub: uidpDerived, wantCalls: []string{uidpDerived}, wantTok: "ok"},
+		"derived failure retries untargeted": {saveSub: uidpDerived, failOn: []string{uidpDerived}, wantCalls: []string{uidpDerived, ""}, wantTok: "ok"},
+		"pin failure does not fall back":     {identityID: uidpPin, failOn: []string{uidpPin}, wantCalls: []string{uidpPin}, wantErr: true},
 		"no token exchanges untargeted":      {wantCalls: []string{""}, wantTok: "ok"},
 	}
 

--- a/internal/token/token_test.go
+++ b/internal/token/token_test.go
@@ -7,11 +7,21 @@ package token
 
 import (
 	"context"
+	"encoding/base64"
 	"errors"
+	"fmt"
+	"slices"
 	"testing"
 
+	sdktoken "chainguard.dev/sdk/auth/token"
 	"github.com/sigstore/cosign/v2/pkg/providers"
 )
+
+// fakeAccessToken builds an unsigned JWT with the given sub claim.
+func fakeAccessToken(sub string) string {
+	payload := base64.RawURLEncoding.EncodeToString(fmt.Appendf(nil, `{"sub":%q}`, sub))
+	return "header." + payload + ".sig"
+}
 
 // fakeProvider is a controllable ambient OIDC provider for tests.
 type fakeProvider struct {
@@ -91,6 +101,103 @@ func TestIdentityTokenForExchange(t *testing.T) {
 			}
 			if got := identityTokenForExchange(context.Background(), cfg); got != tc.want {
 				t.Errorf("got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestEffectiveExchangeIdentity verifies the refresh target: an explicit pin wins,
+// otherwise the identity is derived from the current token's sub (else untargeted).
+func TestEffectiveExchangeIdentity(t *testing.T) {
+	const audience = "https://console.example.test"
+
+	tests := map[string]struct {
+		identityID string // explicit pin
+		saveRaw    string // token to write to the cache ("" => none)
+		want       string
+	}{
+		"pin wins without reading cache":   {identityID: "group/pin", saveRaw: fakeAccessToken("group/other"), want: "group/pin"},
+		"derive from current token sub":    {saveRaw: fakeAccessToken("group/derived"), want: "group/derived"},
+		"no token stays untargeted":        {want: ""},
+		"malformed token stays untargeted": {saveRaw: "not-a-jwt", want: ""},
+		"empty sub stays untargeted":       {saveRaw: fakeAccessToken(""), want: ""},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Setenv("XDG_CACHE_HOME", t.TempDir())
+			if tc.saveRaw != "" {
+				if err := sdktoken.Save([]byte(tc.saveRaw), sdktoken.KindAccess, audience); err != nil {
+					t.Fatalf("save token: %v", err)
+				}
+			}
+			cfg := LoginConfig{IdentityID: tc.identityID, Audience: audience}
+			if got := effectiveExchangeIdentity(context.Background(), cfg); got != tc.want {
+				t.Errorf("got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestExchangeAmbient verifies targeting and the monotonic fallback: a derived
+// identity retries untargeted on failure, while an explicit pin does not.
+func TestExchangeAmbient(t *testing.T) {
+	const audience = "https://console.example.test"
+	// Force identityTokenForExchange down the non-ambient path (returns cfg.IdentityToken).
+	t.Setenv("ACTIONS_ID_TOKEN_REQUEST_TOKEN", "")
+	t.Setenv("ACTIONS_ID_TOKEN_REQUEST_URL", "")
+	t.Setenv("TF_CHAINGUARD_IDENTITY_TOKEN", "")
+	testProvider.enabled = false
+
+	orig := stsExchange
+	t.Cleanup(func() { stsExchange = orig })
+
+	tests := map[string]struct {
+		identityID string   // explicit pin
+		saveSub    string   // cached token sub ("" => no token)
+		failOn     []string // identityIDs the exchange should reject
+		wantCalls  []string
+		wantTok    string
+		wantErr    bool
+	}{
+		"derived identity succeeds":          {saveSub: "group/derived", wantCalls: []string{"group/derived"}, wantTok: "ok"},
+		"derived failure retries untargeted": {saveSub: "group/derived", failOn: []string{"group/derived"}, wantCalls: []string{"group/derived", ""}, wantTok: "ok"},
+		"pin failure does not fall back":     {identityID: "group/pin", failOn: []string{"group/pin"}, wantCalls: []string{"group/pin"}, wantErr: true},
+		"no token exchanges untargeted":      {wantCalls: []string{""}, wantTok: "ok"},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Setenv("XDG_CACHE_HOME", t.TempDir())
+			if tc.saveSub != "" {
+				if err := sdktoken.Save([]byte(fakeAccessToken(tc.saveSub)), sdktoken.KindAccess, audience); err != nil {
+					t.Fatalf("save token: %v", err)
+				}
+			}
+			var calls []string
+			stsExchange = func(_ context.Context, _ LoginConfig, _, identityID string) (string, error) {
+				calls = append(calls, identityID)
+				if slices.Contains(tc.failOn, identityID) {
+					return "", errors.New("exchange failed")
+				}
+				return "ok", nil
+			}
+
+			cfg := LoginConfig{
+				IdentityID:    tc.identityID,
+				IdentityToken: "oidc-literal",
+				Issuer:        "https://issuer.example.test",
+				Audience:      audience,
+			}
+			tok, err := exchangeAmbient(context.Background(), cfg)
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("err=%v, wantErr=%v", err, tc.wantErr)
+			}
+			if !tc.wantErr && tok != tc.wantTok {
+				t.Errorf("tok=%q, want %q", tok, tc.wantTok)
+			}
+			if !slices.Equal(calls, tc.wantCalls) {
+				t.Errorf("calls=%v, want %v", calls, tc.wantCalls)
 			}
 		})
 	}


### PR DESCRIPTION
## Problem
Ambient token refresh does an **untargeted** STS exchange (`WithIdentity("")`). When a repo can assume more than one identity (the common case — a separate scoped identity per workflow), the issuer can't disambiguate and returns `no identity found`. So any build that outlives the initial ~1h token (long-running applies) **fails on refresh** unless an identity is pinned.

That pin is brittle: it's environment/workflow-specific, so a single value hardcoded in shared Terraform breaks across different environments (e.g. staging vs. prod) and local runs. It was only ever a stopgap for the untargeted-refresh failure.

## Change
On refresh, target the identity **the current session was minted for**, instead of guessing:
- Derive it from the current (possibly-expired) token's `sub` via `auth.ExtractIssuerAndSubject` (the token's `sub` is set to the assumed identity's UID by the issuer).
- Validate the derived `sub` with `uidp.Valid` before targeting — the same primitive the schema validator applies to a pinned `identity_id`. A malformed `sub` stays untargeted rather than being sent to the exchange.
- An explicit `identity_id` / `TF_CHAINGUARD_IDENTITY` still **takes precedence** (zero change for pinned configs).
- If a **derived** (not pinned) targeted exchange fails, it **retries untargeted** — so behavior is never worse than today (monotonic).
- Cache alias is unchanged (still keyed on the configured `identity_id`); the derived identity is used only as the exchange target.

Result: long-running refreshes work transparently in any environment with no pin required.

## Security
- `sub` is only a **hint** for which identity to target. The issuer still validates the (freshly re-minted) OIDC token against the identity's `claim_match` before granting, so **no identity can be assumed that the OIDC token couldn't already assume** — no escalation, no confused deputy.
- Reading an unverified `sub` from the local token cache is not a new trust boundary: the cache already holds the live access token used for every API call.
- The refresh is **privilege-preserving** — it re-assumes the same identity/capabilities the session already holds (arguably safer than untargeted, which could resolve some *other* matching identity).

## Blast radius
- **Pinned configs: no change.** Only unpinned/ambient refresh paths change, and only toward "fixed or equal" thanks to the untargeted fallback (a derivation bug degrades to today's behavior, not broken auth).
- Interactive (browser) login path is untouched (ambient OIDC exchange path only).
- One documented caveat: multiple ambient identities sharing the default (empty-alias) cache should pin `identity_id` (for cache separation and deterministic refresh) — already the recommended practice.

## Testing
- **Unit** (`internal/token`):
  - `TestEffectiveExchangeIdentity`: pin wins / derive-from-`sub` / no-token / malformed JWT / empty-`sub` / non-UIDP `sub` (all non-derivable cases stay untargeted).
  - `TestExchangeAmbient`: derived success; derived failure → untargeted retry; **pinned failure → no fallback**; no-token → untargeted.
  - Existing `TestIdentityTokenForExchange` still passes.
- **Acceptance** (live, ambient): `TestExchangeAmbientRefreshTargetsSessionIdentity` — with **no `identity_id` set**, forces the cached token to expire and asserts the refresh's STS exchange targets the identity derived from the session's current `sub`. Passed in CI on both acc jobs (TF 1.14 / 1.15).
- `go build` / `go vet` / `gofmt` clean.

## Docs
- Updated the `login_options.identity_id` schema description + generated `docs/index.md`.

## Resolved open questions
- Derived-`sub` shape check: **done** (now validated via `uidp.Valid`, matching the pinned path).
- Interactive (browser) login path: intentionally **out of scope** — it already targets the configured identity and does not do the ambient exchange this PR changes.
