### PR TITLE
fix(provider): refresh token per-RPC instead of caching a static one

### DIFF
--- a/internal/provider/credential.go
+++ b/internal/provider/credential.go
@@ -1,0 +1,33 @@
+/*
+Copyright 2026 Chainguard, Inc.
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package provider
+
+import (
+	"context"
+
+	"google.golang.org/grpc/credentials"
+
+	"github.com/chainguard-dev/terraform-provider-chainguard/internal/token"
+)
+
+// refreshingCredential fetches the token per-RPC via token.Get (cached, or
+// refreshed when expired), so long applies never send a stale token.
+type refreshingCredential struct {
+	loginConfig token.LoginConfig
+}
+
+var _ credentials.PerRPCCredentials = (*refreshingCredential)(nil)
+
+func (c *refreshingCredential) GetRequestMetadata(ctx context.Context, _ ...string) (map[string]string, error) {
+	tok, err := token.Get(ctx, c.loginConfig, false /* forceRefresh */)
+	if err != nil {
+		return nil, err
+	}
+	return map[string]string{"Authorization": "Bearer " + string(tok)}, nil
+}
+
+// RequireTransportSecurity matches the prior auth.NewFromToken(..., false) behavior.
+func (c *refreshingCredential) RequireTransportSecurity() bool { return false }

--- a/internal/provider/credential_test.go
+++ b/internal/provider/credential_test.go
@@ -1,0 +1,90 @@
+/*
+Copyright 2026 Chainguard, Inc.
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package provider
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+	"testing"
+	"time"
+
+	sdktoken "chainguard.dev/sdk/auth/token"
+
+	"github.com/chainguard-dev/terraform-provider-chainguard/internal/token"
+)
+
+// tokenWithExp builds an unsigned JWT carrying the given sub and exp (unix seconds).
+// token.Get / RemainingLife only parse these claims (no signature verification), which
+// is what lets this reproducer be fully local and deterministic.
+func tokenWithExp(sub string, exp int64) string {
+	payload := base64.RawURLEncoding.EncodeToString(fmt.Appendf(nil, `{"sub":%q,"exp":%d}`, sub, exp))
+	return "hdr." + payload + ".sig"
+}
+
+// TestRefreshingCredentialVsStatic is the minimal reproducer of the release-build
+// failure: a client credential captured once at setup keeps emitting a token frozen
+// at construction time, so once that token's ~TTL elapses the server rejects it with
+// Unauthenticated. The refreshingCredential re-reads via token.Get on every RPC and
+// therefore emits whatever the (refreshed) cache currently holds.
+//
+// We model a 1-minute-TTL token: both credentials emit it initially; then we rotate
+// the cache to a fresh token (as token.Get's refresh would do once the first expired)
+// and show the static credential is stuck on the stale token while the refreshing one
+// picks up the new one. No live issuer or long build required.
+func TestRefreshingCredentialVsStatic(t *testing.T) {
+	t.Setenv("XDG_CACHE_HOME", t.TempDir())
+	ctx := context.Background()
+	const audience = "https://console.example.test"
+
+	// token.Get refreshes when a cached token has <60s (tokenLifeBuffer) of life left,
+	// so a "still-usable" short-lived token must sit just above that floor. We use ~2 min
+	// to model a freshly-minted short-TTL token that token.Get will hand back as-is.
+	now := time.Now().Unix()
+	oneMinuteToken := tokenWithExp("group/session", now+120)  // short TTL, still > 60s buffer
+	refreshedToken := tokenWithExp("group/session", now+3600) // what the cache holds after a refresh
+
+	if err := sdktoken.Save([]byte(oneMinuteToken), sdktoken.KindAccess, audience); err != nil {
+		t.Fatalf("seed cache: %v", err)
+	}
+
+	// The buggy path: a credential frozen with the token captured at client construction.
+	staticAuthHeader := "Bearer " + oneMinuteToken
+	// The fix: a credential that re-fetches from the cache (token.Get) on every RPC.
+	refreshing := &refreshingCredential{loginConfig: token.LoginConfig{Audience: audience}}
+
+	// Sanity: before the token rolls over, both emit the same header.
+	md, err := refreshing.GetRequestMetadata(ctx)
+	if err != nil {
+		t.Fatalf("refreshing.GetRequestMetadata: %v", err)
+	}
+	if md["Authorization"] != staticAuthHeader {
+		t.Fatalf("pre-rotate: refreshing emitted %q, want %q", md["Authorization"], staticAuthHeader)
+	}
+
+	// The ~1-min token expires and the cache is refreshed to a new token (token.Get would
+	// do this on the next call). The static credential cannot see this — it holds a string.
+	if err := sdktoken.Save([]byte(refreshedToken), sdktoken.KindAccess, audience); err != nil {
+		t.Fatalf("rotate cache: %v", err)
+	}
+
+	// BUG reproduced: the frozen credential still emits the now-expired token.
+	if staticAuthHeader != "Bearer "+oneMinuteToken {
+		t.Fatalf("static credential unexpectedly changed")
+	}
+
+	// FIX verified: the refreshing credential emits the current (refreshed) token.
+	md, err = refreshing.GetRequestMetadata(ctx)
+	if err != nil {
+		t.Fatalf("refreshing.GetRequestMetadata after rotate: %v", err)
+	}
+	if got, want := md["Authorization"], "Bearer "+refreshedToken; got != want {
+		t.Errorf("post-rotate: refreshing emitted %q, want %q (should track the refreshed cache, not the frozen token)", got, want)
+	}
+	if md["Authorization"] == staticAuthHeader {
+		t.Errorf("refreshing credential is stuck on the stale token — fix ineffective")
+	}
+}

--- a/internal/provider/credential_test.go
+++ b/internal/provider/credential_test.go
@@ -71,11 +71,6 @@ func TestRefreshingCredentialVsStatic(t *testing.T) {
 		t.Fatalf("rotate cache: %v", err)
 	}
 
-	// BUG reproduced: the frozen credential still emits the now-expired token.
-	if staticAuthHeader != "Bearer "+oneMinuteToken {
-		t.Fatalf("static credential unexpectedly changed")
-	}
-
 	// FIX verified: the refreshing credential emits the current (refreshed) token.
 	md, err = refreshing.GetRequestMetadata(ctx)
 	if err != nil {

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -391,19 +391,20 @@ func (pd *providerData) setupClient(ctx context.Context) error {
 
 	// Get the Chainguard token
 	// If it doesn't exist or is expired, attempt to get a new one, depending on login_options
-	cgToken, err := token.Get(ctx, pd.loginConfig, false /* forceRefresh */)
-	if err != nil {
+	if _, err := token.Get(ctx, pd.loginConfig, false /* forceRefresh */); err != nil {
 		return fmt.Errorf("failed to retrieve token. Either no token was found for audience %q or there was an error reading it.\n"+
 			"Please check the value of \"chainguard.console_api\" in your Terraform provider configuration: %s", pd.loginConfig.Audience, err.Error())
 	}
 
+	cred := &refreshingCredential{loginConfig: pd.loginConfig}
+
 	// Generate platform clients.
-	clients, err := newPlatformClients(ctx, string(cgToken), pd.consoleAPI)
+	uaCtx := platform.WithUserAgent(ctx, UserAgent)
+	clients, err := platform.NewPlatformClients(uaCtx, pd.consoleAPI, cred, retryDialOption())
 	if err != nil {
 		return fmt.Errorf("failed to create API clients: %s", err.Error())
 	}
 
-	cred := auth.NewFromToken(ctx, fmt.Sprintf("Bearer %s", string(cgToken)), false)
 	v2, err := clientsv2.NewClients(ctx, pd.consoleAPI, UserAgent, cred, retryDialOption())
 	if err != nil {
 		return fmt.Errorf("failed to create v2beta1 API clients: %s", err.Error())
@@ -417,11 +418,10 @@ func (pd *providerData) setupClient(ctx context.Context) error {
 // setClients replaces both v1 and v2beta1 clients under the mutex.
 // Used by resource_group after re-authenticating with a new organization scope.
 func (pd *providerData) setClients(ctx context.Context, v1 platform.Clients) error {
-	cgToken, err := token.Get(ctx, pd.loginConfig, false)
-	if err != nil {
+	if _, err := token.Get(ctx, pd.loginConfig, false); err != nil {
 		return fmt.Errorf("failed to retrieve token for v2beta1 client refresh: %w", err)
 	}
-	cred := auth.NewFromToken(ctx, fmt.Sprintf("Bearer %s", string(cgToken)), false)
+	cred := &refreshingCredential{loginConfig: pd.loginConfig}
 	v2, err := clientsv2.NewClients(ctx, pd.consoleAPI, UserAgent, cred, retryDialOption())
 	if err != nil {
 		return fmt.Errorf("failed to create v2beta1 API clients: %w", err)


### PR DESCRIPTION
## Problem
The provider constructs its gRPC clients **once** (cached in `pd.client` / `pd.clientV2`) using a **static** bearer credential — `auth.NewFromToken`, whose `GetRequestMetadata` returns the token captured at construction time verbatim, with no refresh. On any `terraform apply` that runs longer than the ~1h access-token lifetime, later Chainguard API calls send the now-expired token and fail:

```
Error: failed to get group
Unauthenticated. Please log in to generate a valid token (chainctl auth login) ...
```

This hits long applies where a Chainguard resource/data source is evaluated well after provider configuration (e.g. a data source refreshed at the end of a multi-stage apply). `token.Get`'s refresh logic runs only once, at client construction, and is never re-consulted for later RPCs.

## Fix
Add `refreshingCredential`, a `credentials.PerRPCCredentials` whose `GetRequestMetadata` calls `token.Get(...)` on **every** RPC — returning the cached token when still valid (a cheap local read) and refreshing it when expired. Wire it into both the v1 (`platform.NewPlatformClients`) and v2beta1 (`clientsv2.NewClients`) clients in `setupClient` **and** `setClients`, replacing the static `auth.NewFromToken`.

## Verification
- **Unit** (`credential_test.go`): with a token in the cache, a static credential keeps emitting the token captured at construction, while `refreshingCredential` reflects the current cache — the exact behavioral difference.
- **End-to-end A/B on real infra:** identical config — a data-source read placed >token-lifetime into an apply (past the server's clock-skew grace) — same token cache seeding, differing **only** by the provider binary:
  - released build → `Unauthenticated` (exit 1)
  - this build → read succeeds, `Apply complete` (exit 0)
- `go build` / `go vet` / `gofmt` clean; existing `internal/token` tests pass.


## Behavior note (release-note worthy)
For **interactive/browser-auth users** on applies that outlive the token: previously the late call simply failed with `Unauthenticated`; now the mid-apply refresh runs. If refresh-token exchange isn't available (or fails), `token.Get` falls back to the **browser login flow** — a login window can open mid-apply (up to 5 minutes, holding the token lock, briefly blocking parallel resources). Better than failing, but new behavior worth a release-note line. CI/ambient users are unaffected (refresh is non-interactive).

## Follow-up (out of scope here)
With per-RPC credentials, the root-group reauth machinery is mostly obsolete: `resource_group.go`'s `waitForRoleBindingPropagation` → `setClients` client rebuild can reduce to force-refreshing the token cache (every client already reads the cache per-RPC; the loop still needs `forceRefresh` since a valid-but-capability-stale token won't refresh otherwise). `newPlatformClients` is the last static-token construction left (prod: that path; tests: `provider_test.go`). Deleting `setClients` + the static helper in a follow-up removes the residue the old pattern could regrow from.
