### PR TITLE
feat(image_repo): gate deletion behind opt-in deletion_protection flag

### DIFF
--- a/docs/resources/image_repo.md
+++ b/docs/resources/image_repo.md
@@ -3,12 +3,12 @@
 page_title: "chainguard_image_repo Resource - terraform-provider-chainguard"
 subcategory: ""
 description: |-
-  Image repo (note: delete is purposefully a no-op).
+  Image repo. Deletion is protected by default; see the deletion_protection attribute.
 ---
 
 # chainguard_image_repo (Resource)
 
-Image repo (note: delete is purposefully a no-op).
+Image repo. Deletion is protected by default; see the deletion_protection attribute.
 
 ## Example Usage
 
@@ -33,6 +33,7 @@ resource "chainguard_image_repo" "example" {
 - `active_tags` (List of String) List of active tags for this repo.
 - `aliases` (List of String) Known aliases for a given image.
 - `bundles` (List of String) List of bundles associated with this repo. Allowed values are enforced by the Chainguard API.
+- `deletion_protection` (Boolean) Prevent this image repo from being deleted through Terraform. Null is treated as true. Set to false (and apply) before destroying.
 - `description` (String) The short description of this repo.
 - `readme` (String) The README for this repo.
 - `sync_config` (Block, Optional) Configuration for catalog syncing. (see [below for nested schema](#nestedblock--sync_config))

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -266,8 +266,8 @@ func checkGroupInviteDestroy(clients platform.Clients) func(*terraform.State) er
 }
 
 // checkImageRepoDestroy verifies the image repo resource was deleted.
-// Note: image_repo delete is a no-op in non-test mode, so this only
-// verifies in acceptance test context where delete is real.
+// Note: image_repo delete is refused while deletion_protection is true or
+// null, so tests must apply deletion_protection = false before final destroy.
 func checkImageRepoDestroy(clients platform.Clients) func(*terraform.State) error {
 	return func(s *terraform.State) error {
 		if clients == nil {

--- a/internal/provider/resource_image_repo.go
+++ b/internal/provider/resource_image_repo.go
@@ -23,11 +23,14 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	registry "chainguard.dev/sdk/proto/platform/registry/v1"
 	"chainguard.dev/sdk/uidp"
 	"chainguard.dev/sdk/validation"
+	"github.com/chainguard-dev/terraform-provider-chainguard/internal/protoutil"
 	"github.com/chainguard-dev/terraform-provider-chainguard/internal/validators"
 )
 
@@ -36,6 +39,7 @@ var (
 	_ resource.Resource                = &imageRepoResource{}
 	_ resource.ResourceWithConfigure   = &imageRepoResource{}
 	_ resource.ResourceWithImportState = &imageRepoResource{}
+	_ resource.ResourceWithModifyPlan  = &imageRepoResource{}
 )
 
 // NewImageRepoResource is a helper function to simplify the provider implementation.
@@ -56,6 +60,8 @@ type imageRepoResourceModel struct {
 	Readme      types.String `tfsdk:"readme"`
 	SyncConfig  types.Object `tfsdk:"sync_config"`
 	Description types.String `tfsdk:"description"`
+	// Client-side deletion gate; never sent to the API. Null is treated as true.
+	DeletionProtection types.Bool `tfsdk:"deletion_protection"`
 	// Image tier (e.g. APPLICATION, BASE, etc.)
 	Tier       types.String `tfsdk:"tier"`
 	Aliases    types.List   `tfsdk:"aliases"`
@@ -86,7 +92,7 @@ func (r *imageRepoResource) Metadata(_ context.Context, req resource.MetadataReq
 // Schema defines the schema for the resource.
 func (r *imageRepoResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = schema.Schema{
-		Description: "Image repo (note: delete is purposefully a no-op).",
+		Description: "Image repo. Deletion is protected by default; see the deletion_protection attribute.",
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
 				Description:   "The UIDP of this repo.",
@@ -109,6 +115,10 @@ func (r *imageRepoResource) Schema(_ context.Context, _ resource.SchemaRequest, 
 				Description: "List of bundles associated with this repo. Allowed values are enforced by the Chainguard API.",
 				Optional:    true,
 				ElementType: types.StringType,
+			},
+			"deletion_protection": schema.BoolAttribute{
+				Description: "Prevent this image repo from being deleted through Terraform. Null is treated as true. Set to false (and apply) before destroying.",
+				Optional:    true,
 			},
 			"readme": schema.StringAttribute{
 				Description: "The README for this repo.",
@@ -249,6 +259,34 @@ func validDescriptionValue(s string) error {
 // ImportState imports resources by ID into the current Terraform state.
 func (r *imageRepoResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
 	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
+}
+
+// ModifyPlan warns on destroy plans: that the apply will fail while
+// deletion_protection is true or null, or that deletion is permanent once it
+// is false. Enforcement happens in Delete; warnings here are plan-time UX only.
+func (r *imageRepoResource) ModifyPlan(ctx context.Context, req resource.ModifyPlanRequest, resp *resource.ModifyPlanResponse) {
+	// Only whole-resource destroy plans are of interest: plan is null, state is not.
+	if !req.Plan.Raw.IsNull() || req.State.Raw.IsNull() {
+		return
+	}
+
+	var state imageRepoResourceModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if protoutil.DefaultBool(state.DeletionProtection, true) {
+		resp.Diagnostics.AddWarning(
+			"image repo protected from deletion",
+			fmt.Sprintf("This plan destroys image repo %q, but deletion_protection is true or null so the apply will fail. To delete this repo, apply deletion_protection = false first.", state.ID.ValueString()),
+		)
+		return
+	}
+	resp.Diagnostics.AddWarning(
+		"image repo deletion is permanent",
+		fmt.Sprintf("This plan permanently deletes image repo %q and its tags from the Chainguard registry. Recovery requires contacting Chainguard support.", state.ID.ValueString()),
+	)
 }
 
 // repoLocks provides per-key locking so that operations on different repos
@@ -704,33 +742,42 @@ func (r *imageRepoResource) Update(ctx context.Context, req resource.UpdateReque
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
 
-// Delete is purposefully a no-op so we don't accidentally delete repos with terraform.
-// Instead, delete them with "chainctl img rm".
+// Delete deletes the resource and removes the Terraform state on success.
 func (r *imageRepoResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
-	// When not running acceptance tests, add an error to resp so Terraform does not automatically remove this resource from state.
-	// See https://developer.hashicorp.com/terraform/plugin/framework/resources/delete#caveats for details.
-	if !r.prov.testing {
-		resp.Diagnostics.AddError("not implemented", "Image repos cannot be deleted through Terraform. Use `chainctl img repo rm` to manually delete.")
-		return
-	}
-
 	// Read the current state into the resource model.
 	var state imageRepoResourceModel
 	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	tflog.Info(ctx, fmt.Sprintf("ACCEPTANCE TEST: delete image repo request: %s", state.ID))
+	id := state.ID.ValueString()
+
+	// NB: When not set, deletion_protection is treated as true.
+	// Erroring here keeps the resource in state; deletion requires two steps:
+	// apply deletion_protection = false, then run the destroy again.
+	if protoutil.DefaultBool(state.DeletionProtection, true) {
+		resp.Diagnostics.AddError(
+			"image repo protected from deletion",
+			fmt.Sprintf("Image repo %q cannot be deleted because deletion_protection is true or null. Deleting an image repo permanently removes it and its tags from the Chainguard registry; recovery requires contacting Chainguard support. To delete this repo, apply deletion_protection = false, then run the destroy again.", id),
+		)
+		return
+	}
+	tflog.Info(ctx, fmt.Sprintf("delete image repo request: %s", id))
 
 	// Lock to prevent concurrent operations on the same repo.
-	unlock := lockRepo(state.ID.ValueString())
+	unlock := lockRepo(id)
 	defer unlock()
 
-	id := state.ID.ValueString()
 	_, err := r.prov.client.Registry().Registry().DeleteRepo(ctx, &registry.DeleteRepoRequest{
 		Id: id,
 	})
 	if err != nil {
+		// The repo may already be gone, or recreated under a new UIDP by the
+		// entitlements reconciler; treat NotFound as a successful delete, like
+		// chainctl's --allow-missing.
+		if status.Code(err) == codes.NotFound {
+			return
+		}
 		resp.Diagnostics.Append(errorToDiagnostic(err, fmt.Sprintf("failed to delete image repo %q", id)))
 		return
 	}

--- a/internal/provider/resource_image_repo_test.go
+++ b/internal/provider/resource_image_repo_test.go
@@ -19,13 +19,14 @@ import (
 )
 
 type testRepo struct {
-	parentID   string
-	name       string
-	bundles    string
-	readme     string
-	tier       string
-	aliases    string
-	activeTags string
+	parentID           string
+	name               string
+	bundles            string
+	readme             string
+	tier               string
+	aliases            string
+	activeTags         string
+	deletionProtection string
 }
 
 func TestImageRepo(t *testing.T) {
@@ -59,6 +60,10 @@ func TestImageRepo(t *testing.T) {
 		aliases:    `["image:97", "image:98", "image:99"]`,
 		activeTags: `["tag4", "tag5", "tag6"]`,
 	}
+
+	// Unlock deletion so the framework's final destroy can succeed.
+	unprotected := update2
+	unprotected.deletionProtection = "false"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
@@ -125,6 +130,23 @@ func TestImageRepo(t *testing.T) {
 					resource.TestCheckResourceAttr(`chainguard_image_repo.example`, `active_tags.2`, "tag6"),
 				),
 			},
+
+			// Destroy while deletion_protection is unset (null): protected by default.
+			{
+				Config:      testImageRepo(update2),
+				Destroy:     true,
+				ExpectError: regexp.MustCompile(`deletion_protection`),
+			},
+
+			// Apply deletion_protection = false to unlock deletion. The
+			// framework's automatic final destroy plus CheckDestroy proves
+			// the repo is then really deleted.
+			{
+				Config: testImageRepo(unprotected),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(`chainguard_image_repo.example`, `deletion_protection`, "false"),
+				),
+			},
 		},
 	})
 }
@@ -157,6 +179,7 @@ resource "chainguard_image_repo" "example" {
   %s
   %s
   %s
+  %s
 }
 `
 	var bundlesLine string
@@ -184,7 +207,12 @@ resource "chainguard_image_repo" "example" {
 		activeTagsLine = fmt.Sprintf("active_tags = %s", repo.activeTags)
 	}
 
-	return fmt.Sprintf(tmpl, repo.parentID, repo.name, bundlesLine, readmeLine, tierLine, aliasesLine, activeTagsLine)
+	var deletionProtectionLine string
+	if repo.deletionProtection != "" {
+		deletionProtectionLine = fmt.Sprintf("deletion_protection = %s", repo.deletionProtection)
+	}
+
+	return fmt.Sprintf(tmpl, repo.parentID, repo.name, bundlesLine, readmeLine, tierLine, aliasesLine, activeTagsLine, deletionProtectionLine)
 }
 
 func TestLockRepo_SameKeySerializes(t *testing.T) {


### PR DESCRIPTION
## What

Makes `chainguard_image_repo` deletable through Terraform, gated behind a new `deletion_protection` attribute that is **protected by default**:

- `deletion_protection` (bool, Optional). **Null is treated as true** — existing configs see zero plan diff and remain fully protected. Deleting a repo is a deliberate two-step: apply `deletion_protection = false`, then destroy.
- `Delete()` errors while protected (keeping the resource in state), and calls `DeleteRepo` once unlocked. `NotFound` on delete is treated as success, matching `chainctl img repo rm --allow-missing` (the repo may already be gone, or recreated under a new UIDP by the entitlements reconciler).
- `ModifyPlan` adds plan-time *warnings* on destroy plans: "the apply will fail" while protected, and a permanence warning once unlocked. Enforcement stays apply-time only, per ecosystem practice.
- The `r.prov.testing` bypass is removed from `Delete` — acceptance tests now exercise the exact code path users do. (`prov.testing` is untouched at its other call sites, including `chainguard_image_tag`, which keeps its no-op delete for now.)

## Why

- Delete has been a hard "not implemented" error since the resource landed ([mono PR #12033](https://github.com/chainguard-dev/mono/pull/12033), July 2023), because Chainguard's own catalog IaC manages every public repo with this resource and an accidental `terraform destroy` there would be catastrophic. That PR sketched a `deletion_protection`-style flag (à la GCP `sql_database_instance`) as the intended eventual design — this PR builds it.
- Customers repeatedly hit the wall: repos removed from config can only be cleaned up out-of-band with `chainctl`, leaving Terraform state and reality drifting (most recently raised by Mark43, June 2026).
- The null-means-protected mechanics copy the in-house precedent, `chainguard_group.verified_protection`: `Optional`-only, no `Computed`/default, so **no state upgrade and no spurious `UpdateRepo` calls** for existing users — including our own catalog IaC, which stays protected without touching a line of config.

## Testing

- `TestImageRepo` gains two steps: a destroy with the flag unset asserting the protection error (proving the default every existing user sits on), then an apply of `deletion_protection = false` so the framework's automatic final destroy + `CheckDestroy` proves the unlock works end to end.
- `go build`, `go vet`, and `go test ./internal/provider/...` pass locally. (The pre-existing `internal/token` `TestExchangeAmbient` failure on `main` is unrelated.)
- [ ] Manual verification of the `ModifyPlan` destroy-plan warnings against a dev org (terraform-plugin-testing cannot assert warnings — `ExpectError` is errors-only and plan JSON carries no warning diagnostics). Output to be pasted here before merge: `terraform plan -destroy` with the flag null → "image repo protected from deletion" warning; with `deletion_protection = false` → permanence warning.

Docs regenerated with tfplugindocs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)