### PR TITLE
feat(group): add kind attribute, name update mask fields explicitly

### DIFF
--- a/docs/resources/group.md
+++ b/docs/resources/group.md
@@ -37,6 +37,7 @@ resource "chainguard_group" "example_sub" {
 ### Optional
 
 - `description` (String) Description of this IAM group.
+- `kind` (String) The organization kind. Required when creating a verified organization (top-level group); may only be set on verified organizations. Subgroups inherit kind from their organization. One of: AWS_MARKETPLACE, CUSTOMER, DEV, INFRA, STARTER.
 - `parent_id` (String) Parent group (organization or folder) of this group. If not set, this group is an organization.
 - `verified` (Boolean) Whether the organization has been verified by a Chainguardian. Only applicable to organizations (top-level groups).
 - `verified_protection` (Boolean) Prevent the group from being unverified through Terraform. Null is treated as true.

--- a/internal/provider/resource_group.go
+++ b/internal/provider/resource_group.go
@@ -8,11 +8,14 @@ package provider
 import (
 	"context"
 	"fmt"
+	"slices"
+	"strings"
 	"time"
 
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -58,6 +61,7 @@ type groupResourceModel struct {
 	ParentID           types.String `tfsdk:"parent_id"`
 	Verified           types.Bool   `tfsdk:"verified"`
 	VerifiedProtection types.Bool   `tfsdk:"verified_protection"`
+	Kind               types.String `tfsdk:"kind"`
 	ResourceLimits     types.Map    `tfsdk:"resource_limits"`
 }
 
@@ -72,6 +76,16 @@ func (r *groupResource) Metadata(_ context.Context, req resource.MetadataRequest
 
 // Schema defines the schema for the resource.
 func (r *groupResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+	// Sorted so the generated docs are stable across map iteration order.
+	orgKinds := make([]string, 0, len(iamv2.OrgKind_value))
+	for name, val := range iamv2.OrgKind_value {
+		if val == 0 {
+			continue
+		}
+		orgKinds = append(orgKinds, strings.TrimPrefix(name, "ORG_KIND_"))
+	}
+	slices.Sort(orgKinds)
+
 	resp.Schema = schema.Schema{
 		Description: "IAM Group on the Chainguard platform.",
 		Attributes: map[string]schema.Attribute{
@@ -103,6 +117,16 @@ func (r *groupResource) Schema(_ context.Context, _ resource.SchemaRequest, resp
 				Description: "Prevent the group from being unverified through Terraform. Null is treated as true.",
 				Optional:    true,
 			},
+			"kind": schema.StringAttribute{
+				Description: "The organization kind. Required when creating a verified organization (top-level group); may only be set on verified organizations. Subgroups inherit kind from their organization. One of: " + strings.Join(orgKinds, ", ") + ".",
+				Optional:    true,
+				Computed:    true,
+				Validators: []validator.String{
+					stringvalidator.OneOf(orgKinds...),
+					stringvalidator.ConflictsWith(path.MatchRoot("parent_id")),
+				},
+				PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
+			},
 			"resource_limits": schema.MapAttribute{
 				Description: "Maximum number of resources allowed by type.",
 				Computed:    true,
@@ -133,6 +157,7 @@ func (r *groupResource) Create(ctx context.Context, req resource.CreateRequest, 
 			Name:        plan.Name.ValueString(),
 			Description: plan.Description.ValueString(),
 			Verified:    plan.Verified.ValueBool(),
+			Kind:        iamv2.OrgKind(iamv2.OrgKind_value["ORG_KIND_"+plan.Kind.ValueString()]),
 		},
 	}
 	// Only include Parent UIDP for non-organization (folder) groups.
@@ -149,6 +174,13 @@ func (r *groupResource) Create(ctx context.Context, req resource.CreateRequest, 
 
 	// Save group details in the state.
 	plan.ID = types.StringValue(g.GetUid())
+	// Kind is computed and must resolve to a known value: subgroups
+	// inherit it from their organization, unverified groups leave it null.
+	if k := g.GetKind(); k != iamv2.OrgKind_ORG_KIND_UNSPECIFIED {
+		plan.Kind = types.StringValue(strings.TrimPrefix(k.String(), "ORG_KIND_"))
+	} else {
+		plan.Kind = types.StringNull()
+	}
 	if len(g.GetResourceLimits()) > 0 {
 		rl, diags := types.MapValueFrom(ctx, types.Int32Type, g.GetResourceLimits())
 		resp.Diagnostics.Append(diags...)
@@ -298,6 +330,12 @@ func (r *groupResource) Read(ctx context.Context, req resource.ReadRequest, resp
 	if !state.Verified.IsNull() || g.GetVerified() {
 		state.Verified = types.BoolValue(g.GetVerified())
 	}
+	// Kind is computed: reflect the server value (null when unset).
+	if k := g.GetKind(); k != iamv2.OrgKind_ORG_KIND_UNSPECIFIED {
+		state.Kind = types.StringValue(strings.TrimPrefix(k.String(), "ORG_KIND_"))
+	} else {
+		state.Kind = types.StringNull()
+	}
 
 	if len(g.GetResourceLimits()) > 0 {
 		rl, diags := types.MapValueFrom(ctx, types.Int32Type, g.GetResourceLimits())
@@ -324,14 +362,25 @@ func (r *groupResource) update(ctx context.Context, data *groupResourceModel, st
 		return diag.NewErrorDiagnostic("cannot unverify group", fmt.Sprintf("group %s is verified and verified_protection is true or null; apply verified_protection = false before attempting to unverify this group", state.ID.ValueString()))
 	}
 
+	ug := &iamv2.Group{
+		Uid:         data.ID.ValueString(),
+		Name:        data.Name.ValueString(),
+		Description: data.Description.ValueString(),
+		Verified:    data.Verified.ValueBool(),
+	}
+	// The server treats a wildcard mask as intent to update every field --
+	// including kind and status, which this resource does not set -- and
+	// rejects such updates once those fields hold values. Kind must also be
+	// named explicitly to take effect, so name only the managed fields and
+	// kind only when it changes.
+	paths := []string{"name", "description", "verified"}
+	if !data.Kind.IsUnknown() && !data.Kind.IsNull() && !data.Kind.Equal(state.Kind) {
+		ug.Kind = iamv2.OrgKind(iamv2.OrgKind_value["ORG_KIND_"+data.Kind.ValueString()])
+		paths = append(paths, "kind")
+	}
 	g, err := r.prov.clientV2.IAM().GroupsService().UpdateGroup(ctx, &iamv2.UpdateGroupRequest{
-		Group: &iamv2.Group{
-			Uid:         data.ID.ValueString(),
-			Name:        data.Name.ValueString(),
-			Description: data.Description.ValueString(),
-			Verified:    data.Verified.ValueBool(),
-		},
-		UpdateMask: &fieldmaskpb.FieldMask{Paths: []string{"*"}},
+		Group:      ug,
+		UpdateMask: &fieldmaskpb.FieldMask{Paths: paths},
 	})
 	if err != nil {
 		return errorToDiagnostic(err, fmt.Sprintf("failed to update group %q", data.ID.ValueString()))

--- a/internal/provider/resource_group_test.go
+++ b/internal/provider/resource_group_test.go
@@ -77,7 +77,7 @@ func TestGroupResource_update(t *testing.T) {
 					Name:        "name",
 					Description: "foo",
 				},
-				UpdateMask: &fieldmaskpb.FieldMask{Paths: []string{"*"}},
+				UpdateMask: &fieldmaskpb.FieldMask{Paths: []string{"name", "description", "verified"}},
 			},
 			Result: &iamv2.Group{
 				Uid:         "id",
@@ -104,7 +104,7 @@ func TestGroupResource_update(t *testing.T) {
 					Name:     "name",
 					Verified: true,
 				},
-				UpdateMask: &fieldmaskpb.FieldMask{Paths: []string{"*"}},
+				UpdateMask: &fieldmaskpb.FieldMask{Paths: []string{"name", "description", "verified"}},
 			},
 			Result: &iamv2.Group{
 				Uid:      "id",
@@ -131,7 +131,7 @@ func TestGroupResource_update(t *testing.T) {
 					Name:     "name",
 					Verified: true,
 				},
-				UpdateMask: &fieldmaskpb.FieldMask{Paths: []string{"*"}},
+				UpdateMask: &fieldmaskpb.FieldMask{Paths: []string{"name", "description", "verified"}},
 			},
 			Result: &iamv2.Group{
 				Uid:      "id",
@@ -158,7 +158,7 @@ func TestGroupResource_update(t *testing.T) {
 					Uid:  "id",
 					Name: "name",
 				},
-				UpdateMask: &fieldmaskpb.FieldMask{Paths: []string{"*"}},
+				UpdateMask: &fieldmaskpb.FieldMask{Paths: []string{"name", "description", "verified"}},
 			},
 			Result: &iamv2.Group{
 				Uid:  "id",
@@ -207,6 +207,69 @@ func TestGroupResource_update(t *testing.T) {
 		},
 		wantDiag: diag.NewErrorDiagnostic("cannot unverify group", "group id is verified and verified_protection is true or null; apply verified_protection = false before attempting to unverify this group"),
 	}, {
+		name: "update kind",
+		onUpdateGroup: test.On[*iamv2.UpdateGroupRequest, *iamv2.Group]{
+			Given: &iamv2.UpdateGroupRequest{
+				Group: &iamv2.Group{
+					Uid:      "id",
+					Name:     "name",
+					Verified: true,
+					Kind:     iamv2.OrgKind_ORG_KIND_CUSTOMER,
+				},
+				UpdateMask: &fieldmaskpb.FieldMask{Paths: []string{"name", "description", "verified", "kind"}},
+			},
+			Result: &iamv2.Group{
+				Uid:      "id",
+				Name:     "name",
+				Verified: true,
+				Kind:     iamv2.OrgKind_ORG_KIND_CUSTOMER,
+			},
+		},
+		data: groupResourceModel{
+			ID:             types.StringValue("id"),
+			Name:           types.StringValue("name"),
+			Verified:       types.BoolValue(true),
+			Kind:           types.StringValue("CUSTOMER"),
+			ResourceLimits: types.MapNull(types.Int32Type),
+		},
+		state: groupResourceModel{
+			ID:       types.StringValue("id"),
+			Name:     types.StringValue("name"),
+			Verified: types.BoolValue(true),
+			Kind:     types.StringValue("STARTER"),
+		},
+	}, {
+		name: "unchanged kind stays out of the mask",
+		onUpdateGroup: test.On[*iamv2.UpdateGroupRequest, *iamv2.Group]{
+			Given: &iamv2.UpdateGroupRequest{
+				Group: &iamv2.Group{
+					Uid:      "id",
+					Name:     "name",
+					Verified: true,
+				},
+				UpdateMask: &fieldmaskpb.FieldMask{Paths: []string{"name", "description", "verified"}},
+			},
+			Result: &iamv2.Group{
+				Uid:      "id",
+				Name:     "name",
+				Verified: true,
+				Kind:     iamv2.OrgKind_ORG_KIND_CUSTOMER,
+			},
+		},
+		data: groupResourceModel{
+			ID:             types.StringValue("id"),
+			Name:           types.StringValue("name"),
+			Verified:       types.BoolValue(true),
+			Kind:           types.StringValue("CUSTOMER"),
+			ResourceLimits: types.MapNull(types.Int32Type),
+		},
+		state: groupResourceModel{
+			ID:       types.StringValue("id"),
+			Name:     types.StringValue("name"),
+			Verified: types.BoolValue(true),
+			Kind:     types.StringValue("CUSTOMER"),
+		},
+	}, {
 		name: "update sets resource_limits to null when empty",
 		onUpdateGroup: test.On[*iamv2.UpdateGroupRequest, *iamv2.Group]{
 			Given: &iamv2.UpdateGroupRequest{
@@ -214,7 +277,7 @@ func TestGroupResource_update(t *testing.T) {
 					Uid:  "id",
 					Name: "name",
 				},
-				UpdateMask: &fieldmaskpb.FieldMask{Paths: []string{"*"}},
+				UpdateMask: &fieldmaskpb.FieldMask{Paths: []string{"name", "description", "verified"}},
 			},
 			Result: &iamv2.Group{
 				Uid:  "id",
@@ -254,6 +317,7 @@ func TestGroupResource_update(t *testing.T) {
 				Description:        c.data.Description,
 				Verified:           c.data.Verified,
 				VerifiedProtection: c.data.VerifiedProtection,
+				Kind:               c.data.Kind,
 				ResourceLimits:     c.data.ResourceLimits,
 			}
 			gotDiag := r.update(ctx, &dc, c.state)
@@ -305,7 +369,7 @@ func TestGroupResource_updateResourceLimits(t *testing.T) {
 										Uid:  "id",
 										Name: "name",
 									},
-									UpdateMask: &fieldmaskpb.FieldMask{Paths: []string{"*"}},
+									UpdateMask: &fieldmaskpb.FieldMask{Paths: []string{"name", "description", "verified"}},
 								},
 								Result: &iamv2.Group{
 									Uid:            "id",


### PR DESCRIPTION
the v2beta1 API requires `kind` when creating verified organizations, which makes creating one through this provider impossible today (`InvalidArgument: kind is required for verified root groups`). adds an optional+computed `kind` attribute to `chainguard_group` — computed because subgroups inherit kind from their organization and existing organizations may already have a kind set, so configs that omit it must not drift.

updates also stop sending a wildcard field mask: the API treats `*` as intent to update every field — including `kind` and `status`, which this resource never sets — and can reject such updates once those fields hold values. kind changes must also be named in the mask explicitly to take effect, so the mask now names the managed fields and includes `kind` only when it actually changes.