### PR TITLE
build(deps): bump chainguard.dev/sdk to 0.1.141 and add Advisory() to v2 client mock

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,8 +3,8 @@ module github.com/chainguard-dev/terraform-provider-chainguard
 go 1.26.4
 
 require (
-	chainguard.dev/apko v1.2.18
-	chainguard.dev/sdk v0.1.119
+	chainguard.dev/apko v1.2.23
+	chainguard.dev/sdk v0.1.141
 	github.com/chainguard-dev/clog v1.8.1
 	github.com/coreos/go-oidc/v3 v3.20.0
 	github.com/google/go-cmp v0.7.0

--- a/go.sum
+++ b/go.sum
@@ -1,11 +1,11 @@
-chainguard.dev/apko v1.2.18 h1:CFZ0YG7t6U0k2mDYs22l67SF7ukHtkyXVJFj/qhf8+c=
-chainguard.dev/apko v1.2.18/go.mod h1:G/xIzbXWAeBNWJKtcVbJpTSrmgb1ElL382XlqVLh95Q=
+chainguard.dev/apko v1.2.23 h1:gJcWEObpJ3delpNYr78eTcb3KP+jIgO4G/AEHOnX08M=
+chainguard.dev/apko v1.2.23/go.mod h1:bXhGAcxyjY/mG0OOD5GfWUYt5YFCZmdPGfGYtnlRLWU=
 chainguard.dev/go-grpc-kit v0.17.17 h1:Jwhc0zyUwQbC2hNcsi+YMeUX/JUnM+dXVCkTw6wtPzs=
 chainguard.dev/go-grpc-kit v0.17.17/go.mod h1:qn0meP6RtrbLicE1bgBZnnVU9dvX95eLs0x0T6kZ+b4=
 chainguard.dev/go-oidctest v0.4.0 h1:B9YTfoa1WtsrEg0wnFeSP7i9tth0LO+GICm2j8HOgWI=
 chainguard.dev/go-oidctest v0.4.0/go.mod h1:IIic4S3je1I7Acy3bqPtaSPefGEsQDzUp7NJF35MPV4=
-chainguard.dev/sdk v0.1.119 h1:M8/7Q6OjISkZpGek2EsTpFyb2CKemu/90k/NNA2JbdM=
-chainguard.dev/sdk v0.1.119/go.mod h1:3Pub6HVK2Zy4btJgijBRXkVZX8l/kmrYJ99c5DaRSa0=
+chainguard.dev/sdk v0.1.141 h1:2jncDNv4eejKgLDhjMFxEXRAyaiB1Vv32sy6pNWJLxA=
+chainguard.dev/sdk v0.1.141/go.mod h1:WIaM60bR6qU84RvE45u4QkOh+BN2uc1nfHuZYLnRfvU=
 cloud.google.com/go/auth v0.20.0 h1:kXTssoVb4azsVDoUiF8KvxAqrsQcQtB53DcSgta74CA=
 cloud.google.com/go/auth v0.20.0/go.mod h1:942/yi/itH1SsmpyrbnTMDgGfdy2BUqIKyd0cyYLc5Q=
 cloud.google.com/go/auth/oauth2adapt v0.2.8 h1:keo8NaayQZ6wimpNSmW5OPc283g65QNIiLpZnkHRbnc=

--- a/internal/provider/resource_group_test.go
+++ b/internal/provider/resource_group_test.go
@@ -19,6 +19,7 @@ import (
 
 	"google.golang.org/protobuf/types/known/fieldmaskpb"
 
+	advisory "chainguard.dev/sdk/proto/chainguard/platform/advisory/v2beta1"
 	clientsv2 "chainguard.dev/sdk/proto/chainguard/platform/clients/v2beta1"
 	iamv2 "chainguard.dev/sdk/proto/chainguard/platform/iam/v2beta1"
 	iamv2test "chainguard.dev/sdk/proto/chainguard/platform/iam/v2beta1/test"
@@ -35,6 +36,7 @@ type mockV2PlatformClients struct {
 
 var _ clientsv2.Clients = (*mockV2PlatformClients)(nil)
 
+func (m *mockV2PlatformClients) Advisory() advisory.Clients    { return nil }
 func (m *mockV2PlatformClients) IAM() iamv2.Clients            { return m.iamClients }
 func (m *mockV2PlatformClients) Registry() registry.Clients    { return nil }
 func (m *mockV2PlatformClients) Vulnerabilities() vuln.Clients { return nil }


### PR DESCRIPTION
Supersedes the Dependabot bump #596. SDK `0.1.141` adds `Advisory()` to the `v2beta1.Clients` interface, so the bump alone fails to compile (the `mockV2PlatformClients` test mock doesn't implement it, which is why #596 is red).

This bundles the mock update with the bump since the mock references the advisory client package that only exists in `0.1.141`. Also bumps `apko` to `1.2.23` as a required transitive dependency.