### PR TITLE
fix(group): stop replacing API clients after organization create

### DIFF
--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -414,30 +414,3 @@ func (pd *providerData) setupClient(ctx context.Context) error {
 	pd.clientV2 = v2
 	return nil
 }
-
-// setClients replaces both v1 and v2beta1 clients under the mutex.
-// Used by resource_group after re-authenticating with a new organization scope.
-func (pd *providerData) setClients(ctx context.Context, v1 platform.Clients) error {
-	if _, err := token.Get(ctx, pd.loginConfig, false); err != nil {
-		return fmt.Errorf("failed to retrieve token for v2beta1 client refresh: %w", err)
-	}
-	cred := &refreshingCredential{loginConfig: pd.loginConfig}
-	v2, err := clientsv2.NewClients(ctx, pd.consoleAPI, UserAgent, cred, retryDialOption())
-	if err != nil {
-		return fmt.Errorf("failed to create v2beta1 API clients: %w", err)
-	}
-
-	pd.clientMu.Lock()
-	defer pd.clientMu.Unlock()
-	oldV1 := pd.client
-	oldV2 := pd.clientV2
-	pd.client = v1
-	pd.clientV2 = v2
-	if oldV1 != nil {
-		oldV1.Close()
-	}
-	if oldV2 != nil {
-		oldV2.Close()
-	}
-	return nil
-}

--- a/internal/provider/provider_client_init_test.go
+++ b/internal/provider/provider_client_init_test.go
@@ -6,45 +6,10 @@ SPDX-License-Identifier: Apache-2.0
 package provider
 
 import (
-	"sync"
 	"testing"
 
 	platform "chainguard.dev/sdk/proto/platform"
 )
-
-// setClient is a test helper that sets only the v1 client under the mutex.
-// Production code uses setClients which also refreshes the v2beta1 client,
-// but these tests only exercise the mutex-protected swap pattern.
-func (pd *providerData) setClient(clients platform.Clients) {
-	pd.clientMu.Lock()
-	defer pd.clientMu.Unlock()
-	pd.client = clients
-}
-
-// TestSetClient_ThreadSafe verifies that setClient and the double-check
-// in setupClient work correctly under concurrent access.
-func TestSetClient_ThreadSafe(t *testing.T) {
-	pd := &providerData{}
-
-	// Initially nil.
-	if pd.client != nil {
-		t.Fatal("client should be nil initially")
-	}
-
-	// setClient sets the client under the mutex.
-	fake := &fakeClients{}
-	pd.setClient(fake)
-	if pd.client != fake {
-		t.Fatal("client should be set after setClient")
-	}
-
-	// setClient can replace the client.
-	fake2 := &fakeClients{}
-	pd.setClient(fake2)
-	if pd.client != fake2 {
-		t.Fatal("client should be replaced after second setClient")
-	}
-}
 
 // TestSetupClient_DoubleCheckSkipsWhenSet verifies that setupClient is a
 // no-op when the client is already initialized (the double-check pattern).
@@ -63,29 +28,9 @@ func TestSetupClient_DoubleCheckSkipsWhenSet(t *testing.T) {
 	}
 }
 
-// TestSetClient_ConcurrentAccess verifies that concurrent setClient calls
-// don't race.
-func TestSetClient_ConcurrentAccess(t *testing.T) {
-	pd := &providerData{}
-
-	var wg sync.WaitGroup
-	for i := range 10 {
-		wg.Go(func() {
-			pd.setClient(&fakeClients{id: i})
-		})
-	}
-	wg.Wait()
-
-	// After all goroutines complete, client should be non-nil (last writer wins).
-	if pd.client == nil {
-		t.Fatal("client should be non-nil after concurrent setClient calls")
-	}
-}
-
 // fakeClients satisfies platform.Clients for testing.
 type fakeClients struct {
 	platform.Clients
-	id int
 }
 
 func (f *fakeClients) Close() error { return nil }

--- a/internal/provider/resource_group.go
+++ b/internal/provider/resource_group.go
@@ -29,7 +29,6 @@ import (
 	"google.golang.org/protobuf/types/known/fieldmaskpb"
 
 	iamv2 "chainguard.dev/sdk/proto/chainguard/platform/iam/v2beta1"
-	"chainguard.dev/sdk/proto/platform"
 	iam "chainguard.dev/sdk/proto/platform/iam/v1"
 	"chainguard.dev/sdk/uidp"
 	"github.com/chainguard-dev/terraform-provider-chainguard/internal/protoutil"
@@ -193,31 +192,28 @@ func (r *groupResource) Create(ctx context.Context, req resource.CreateRequest, 
 	}
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
 
-	// Attempt to reauthenticate if an organization was created so token
-	// has new organization in scope.
+	// Reauthenticate if an organization was created so the cached token has
+	// the new organization in scope.
 	if uidp.InRoot(g.GetUid()) {
-		cfg := r.prov.loginConfig
-		clients, err := r.waitForRoleBindingPropagation(ctx, g.GetUid(), cfg)
-		if err != nil {
+		if err := r.waitForRoleBindingPropagation(ctx, g.GetUid(), r.prov.loginConfig); err != nil {
 			resp.Diagnostics.Append(errorToDiagnostic(err, fmt.Sprintf("failed to verify root group access for %q", g.GetUid())))
-			return
-		}
-		if err := r.prov.setClients(ctx, clients); err != nil {
-			resp.Diagnostics.Append(errorToDiagnostic(err, fmt.Sprintf("failed to refresh clients for %q", g.GetUid())))
 			return
 		}
 	}
 }
 
-// waitForRoleBindingPropagation waits for role binding propagation after organization creation.
-// It polls the API with exponential backoff until the group is accessible or times out.
-// NB: This uses v1 clients because it creates fresh platform.Clients via newPlatformClients,
-// which only constructs v1 clients. This is a transient retry mechanism, not a core CRUD path.
+// waitForRoleBindingPropagation waits for role binding propagation after
+// organization creation. Each attempt force-refreshes the cached token so the
+// new organization is in scope — clients attach the cached token per RPC, so
+// the shared connections pick it up without being replaced. (Replacing them
+// would close connections that concurrent resource operations may still have
+// RPCs in flight on.) It polls with exponential backoff until the group is
+// accessible or times out.
 func (r *groupResource) waitForRoleBindingPropagation(
 	ctx context.Context,
 	groupID string,
 	cfg token.LoginConfig,
-) (platform.Clients, error) {
+) error {
 	const (
 		maxAttempts = 5
 		baseDelay   = 2 * time.Second
@@ -226,19 +222,12 @@ func (r *groupResource) waitForRoleBindingPropagation(
 
 	for attempt := range maxAttempts {
 		// Refresh token to pick up new capabilities
-		cgToken, err := token.Get(ctx, cfg, true /* forceRefresh */)
-		if err != nil {
-			return nil, fmt.Errorf("failed to refresh token: %w", err)
-		}
-
-		// Create new clients with refreshed token
-		clients, err := newPlatformClients(ctx, string(cgToken), r.prov.consoleAPI)
-		if err != nil {
-			return nil, fmt.Errorf("failed to create clients: %w", err)
+		if _, err := token.Get(ctx, cfg, true /* forceRefresh */); err != nil {
+			return fmt.Errorf("failed to refresh token: %w", err)
 		}
 
 		// Verify group is accessible by attempting to list it
-		gl, err := clients.IAM().Groups().List(ctx, &iam.GroupFilter{
+		gl, err := r.prov.client.IAM().Groups().List(ctx, &iam.GroupFilter{
 			Id: groupID,
 		})
 
@@ -249,7 +238,7 @@ func (r *groupResource) waitForRoleBindingPropagation(
 			code := status.Code(err)
 			if code != codes.Unauthenticated && code != codes.PermissionDenied {
 				// Non-auth errors are not recoverable.
-				return nil, fmt.Errorf("failed to list group: %w", err)
+				return fmt.Errorf("failed to list group: %w", err)
 			}
 			tflog.Debug(ctx, "Auth error during propagation (retrying)", map[string]any{
 				"group_id": groupID,
@@ -263,7 +252,7 @@ func (r *groupResource) waitForRoleBindingPropagation(
 				"group_id": groupID,
 				"attempts": attempt + 1,
 			})
-			return clients, nil
+			return nil
 		}
 
 		// Group not yet visible - retry with backoff (unless this was the last attempt)
@@ -281,12 +270,12 @@ func (r *groupResource) waitForRoleBindingPropagation(
 			case <-time.After(delay):
 				// Continue to next attempt
 			case <-ctx.Done():
-				return nil, ctx.Err()
+				return ctx.Err()
 			}
 		}
 	}
 
-	return nil, fmt.Errorf("group %q not found after %d attempts", groupID, maxAttempts)
+	return fmt.Errorf("group %q not found after %d attempts", groupID, maxAttempts)
 }
 
 // Read refreshes the Terraform state with the latest data.


### PR DESCRIPTION
since #585 tokens are fetched per-RPC from the cached login, so the client swap after creating an organization (#60) no longer serves a purpose — the propagation wait already force-refreshes the cached token, and the existing connections pick it up on their next RPC.

the swap was also harmful: since #579 it closes the old connections, so any resource with an RPC in flight during a concurrent organization create fails with `Canceled: grpc: the client connection is closing`. the replacement v1 clients it promoted also carried a static token snapshot, losing per-RPC refresh for the rest of the apply.

`waitForRoleBindingPropagation` now verifies through the shared clients and returns only an error; `setClients` is deleted.