### PR TITLE
Resolve open zizmor code scanning findings

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,10 +4,14 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7
   - package-ecosystem: "gomod"
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7
     groups:
       terraform:
         patterns:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,10 @@ on:
       - "releases/**"
     paths-ignore:
       - "README.md"
-  pull_request_target:
+  # pull_request_target is required so fork PRs can receive OIDC credentials.
+  # Untrusted code is gated behind the reviewer-approved acceptance-tests
+  # environment, see the comments on the test job below.
+  pull_request_target: # zizmor: ignore[dangerous-triggers]
     branches:
       - "main"
     paths-ignore:


### PR DESCRIPTION
Add a 7-day Dependabot cooldown for both ecosystems, and suppress dangerous-triggers on the acceptance test workflow's pull_request_target with an inline ignore. The trigger is required so fork PRs can receive OIDC credentials, and untrusted code is gated behind the reviewer-approved acceptance-tests environment, so the risk is accepted rather than absent. The inline ignore matches how the infra repo handles the same finding.
